### PR TITLE
fix: correct module import casing in test files

### DIFF
--- a/ios/OffloadTests/BrainDumpRepositoryTests.swift
+++ b/ios/OffloadTests/BrainDumpRepositoryTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import SwiftData
-@testable import Offload
+@testable import offload
 
 @MainActor
 final class BrainDumpRepositoryTests: XCTestCase {

--- a/ios/OffloadTests/PlanRepositoryTests.swift
+++ b/ios/OffloadTests/PlanRepositoryTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import SwiftData
-@testable import Offload
+@testable import offload
 
 @MainActor
 final class PlanRepositoryTests: XCTestCase {

--- a/ios/OffloadTests/TaskRepositoryTests.swift
+++ b/ios/OffloadTests/TaskRepositoryTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import SwiftData
-@testable import Offload
+@testable import offload
 
 @MainActor
 final class TaskRepositoryTests: XCTestCase {


### PR DESCRIPTION
## Summary

Fixes the module import casing in the three repository test files to use lowercase `offload` instead of uppercase `Offload`, matching the actual module name.

## Problem

The test files were importing `@testable import Offload`, but the app target's product name is `offload` (lowercase). Swift module names are case-sensitive, causing build failures with "No such module 'Offload'".

## Changes

- ✅ Updated `BrainDumpRepositoryTests.swift`: `@testable import Offload` → `@testable import offload`
- ✅ Updated `PlanRepositoryTests.swift`: `@testable import Offload` → `@testable import offload`
- ✅ Updated `TaskRepositoryTests.swift`: `@testable import Offload` → `@testable import offload`

## Verification

This fix allows the test files to properly import the module and build successfully.

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)