### PR TITLE
fix: resolve SwiftData relationship circular reference errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ iOS application built with SwiftUI and SwiftData, targeting iPhone and iPad.
 
 ## Critical
 
+- ALWAYS create branches before implementing new features or fixes. Consider worktrees for more complex work or refactors.
+- ALWAYS clean up merged branches.
 - ALWAYS keep documentation up to date.
 - ALWAYS run markdownlint prior to committing documentation.
 - DO NOT make README a changelog.  While in development, PR history can be used to track changes, release notes will be used after initial v1 release.

--- a/ios/Offload/Data/Persistence/PersistenceController.swift
+++ b/ios/Offload/Data/Persistence/PersistenceController.swift
@@ -126,8 +126,8 @@ struct PersistenceController {
             )
             let task2 = Task(
                 title: "Schedule dentist appointment",
-                importance: 3,
-                isDone: true
+                isDone: true,
+                importance: 3
             )
 
             context.insert(task1)

--- a/ios/Offload/Domain/Models/HandOffRequest.swift
+++ b/ios/Offload/Domain/Models/HandOffRequest.swift
@@ -19,7 +19,7 @@ final class HandOffRequest {
     var mode: String  // Stored as String for SwiftData compatibility
 
     // Relationships
-    @Relationship(deleteRule: .nullify, inverse: \BrainDumpEntry.handOffRequests)
+    @Relationship(deleteRule: .nullify)
     var brainDumpEntry: BrainDumpEntry?
 
     @Relationship(deleteRule: .cascade, inverse: \HandOffRun.handOffRequest)

--- a/ios/Offload/Domain/Models/HandOffRun.swift
+++ b/ios/Offload/Domain/Models/HandOffRun.swift
@@ -23,7 +23,7 @@ final class HandOffRun {
     var errorMessage: String?
 
     // Relationships
-    @Relationship(deleteRule: .nullify, inverse: \HandOffRequest.runs)
+    @Relationship(deleteRule: .nullify)
     var handOffRequest: HandOffRequest?
 
     @Relationship(deleteRule: .cascade, inverse: \Suggestion.handOffRun)

--- a/ios/Offload/Domain/Models/ListItem.swift
+++ b/ios/Offload/Domain/Models/ListItem.swift
@@ -15,7 +15,7 @@ final class ListItem {
     var isChecked: Bool
 
     // Relationships
-    @Relationship(deleteRule: .nullify, inverse: \ListEntity.items)
+    @Relationship(deleteRule: .nullify)
     var list: ListEntity?
 
     init(

--- a/ios/Offload/Domain/Models/Suggestion.swift
+++ b/ios/Offload/Domain/Models/Suggestion.swift
@@ -19,7 +19,7 @@ final class Suggestion {
     var confidence: Double?
 
     // Relationships
-    @Relationship(deleteRule: .nullify, inverse: \HandOffRun.suggestions)
+    @Relationship(deleteRule: .nullify)
     var handOffRun: HandOffRun?
 
     @Relationship(deleteRule: .cascade, inverse: \SuggestionDecision.suggestion)

--- a/ios/Offload/Domain/Models/SuggestionDecision.swift
+++ b/ios/Offload/Domain/Models/SuggestionDecision.swift
@@ -20,7 +20,7 @@ final class SuggestionDecision {
     var undoOfDecisionId: UUID?
 
     // Relationships
-    @Relationship(deleteRule: .nullify, inverse: \Suggestion.decisions)
+    @Relationship(deleteRule: .nullify)
     var suggestion: Suggestion?
 
     init(

--- a/ios/Offload/Domain/Models/Task.swift
+++ b/ios/Offload/Domain/Models/Task.swift
@@ -22,7 +22,7 @@ final class Task {
     var dueDate: Date?
 
     // Relationships
-    @Relationship(deleteRule: .nullify, inverse: \Plan.tasks)
+    @Relationship(deleteRule: .nullify)
     var plan: Plan?
 
     var category: Category?


### PR DESCRIPTION
## Summary

Fixes the SwiftData `@Relationship` macro circular reference errors that were preventing the project from building. The issue was caused by redundant `inverse` declarations on both sides of bidirectional relationships.

## Problem

SwiftData bidirectional relationships were causing circular macro resolution errors:
- `Suggestion` ↔ `SuggestionDecision`
- `HandOffRequest` ↔ `HandOffRun`
- `Plan` ↔ `Task`
- `ListEntity` ↔ `ListItem`
- `BrainDumpEntry` ↔ `HandOffRequest`
- `HandOffRun` ↔ `Suggestion`

## Solution

In SwiftData, **only the parent side (with the array) should declare the `inverse` relationship**. Removed `inverse` parameter from all child entities (those with optional single references):

### Relationship Fixes

- ✅ `SuggestionDecision.suggestion` - removed inverse (parent: `Suggestion.decisions`)
- ✅ `HandOffRun.handOffRequest` - removed inverse (parent: `HandOffRequest.runs`)
- ✅ `Task.plan` - removed inverse (parent: `Plan.tasks`)
- ✅ `ListItem.list` - removed inverse (parent: `ListEntity.items`)
- ✅ `HandOffRequest.brainDumpEntry` - removed inverse (parent: `BrainDumpEntry.handOffRequests`)
- ✅ `Suggestion.handOffRun` - removed inverse (parent: `HandOffRun.suggestions`)

### Additional Fixes

- ✅ Fixed parameter order in `PersistenceController` sample Task creation (`isDone` before `importance`)
- ✅ Updated AGENTS.md with branch creation and cleanup guidelines

## Verification

✅ **BUILD SUCCEEDED** - Project now builds successfully without errors

## Files Changed

- [HandOffRequest.swift](ios/Offload/Domain/Models/HandOffRequest.swift)
- [HandOffRun.swift](ios/Offload/Domain/Models/HandOffRun.swift)
- [Suggestion.swift](ios/Offload/Domain/Models/Suggestion.swift)
- [SuggestionDecision.swift](ios/Offload/Domain/Models/SuggestionDecision.swift)
- [Task.swift](ios/Offload/Domain/Models/Task.swift)
- [ListItem.swift](ios/Offload/Domain/Models/ListItem.swift)
- [PersistenceController.swift](ios/Offload/Data/Persistence/PersistenceController.swift)
- [AGENTS.md](AGENTS.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)