### PR TITLE
Fix capture entry lookups for hand-off queries

### DIFF
--- a/ios/Offload/Data/Repositories/HandOffRepository.swift
+++ b/ios/Offload/Data/Repositories/HandOffRepository.swift
@@ -36,7 +36,7 @@ final class HandOffRepository {
     func fetchRequestsByEntry(_ entryId: UUID) throws -> [HandOffRequest] {
         let descriptor = FetchDescriptor<HandOffRequest>(
             predicate: #Predicate { request in
-                request.brainDumpEntry?.id == entryId
+                request.captureEntry?.id == entryId
             },
             sortBy: [SortDescriptor(\.requestedAt, order: .reverse)]
         )

--- a/ios/Offload/Data/Repositories/SuggestionRepository.swift
+++ b/ios/Offload/Data/Repositories/SuggestionRepository.swift
@@ -56,7 +56,7 @@ final class SuggestionRepository {
     func fetchPendingSuggestionsForEntry(_ entryId: UUID) throws -> [Suggestion] {
         let descriptor = FetchDescriptor<Suggestion>(
             predicate: #Predicate { suggestion in
-                suggestion.handOffRun?.handOffRequest?.brainDumpEntry?.id == entryId
+                suggestion.handOffRun?.handOffRequest?.captureEntry?.id == entryId
             }
         )
         let suggestions = try modelContext.fetch(descriptor)


### PR DESCRIPTION
## Summary
- update hand-off request fetching to reference the captureEntry relationship
- align pending suggestion query with captureEntry lookups to resolve simulator build errors

## Testing
- Not run (requires macOS/Xcode)

Labels: bug

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957ca3198888330b2d51d0b05bf718a)