### PR TITLE
Improve CI test timing and reuse build artifacts

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -1,4 +1,4 @@
-# Intent: Run code quality checks, build, and unit tests for the iOS app in CI.
+# Intent: Run code quality checks, build, and unit tests for the iOS app in CI with timing instrumentation.
 name: iOS CI
 
 on:
@@ -105,6 +105,9 @@ jobs:
       - name: Show Xcode version
         run: xcodebuild -version
 
+      - name: Show Swift version
+        run: swift --version
+
       - name: List available SDKs
         run: xcodebuild -showsdks
 
@@ -189,9 +192,15 @@ jobs:
             -scheme offload \
             -showdestinations || true
 
-      - name: Build
+      - name: Build for testing (timed)
         run: |
-          set -o pipefail && xcodebuild build \
+          set -euo pipefail
+          log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+          log "Starting build-for-testing (simulator=$SIMULATOR_NAME $SIMULATOR_UDID)"
+          start=$(date +%s)
+
+          set -o pipefail && xcodebuild build-for-testing \
             -project ios/Offload.xcodeproj \
             -scheme offload \
             -sdk iphonesimulator \
@@ -201,11 +210,14 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO
 
+          end=$(date +%s)
+          log "Completed build-for-testing in $((end - start))s"
+
   test-unit:
     name: Unit Tests with Coverage
     runs-on: macos-26
     needs: build
-    timeout-minutes: 15
+    timeout-minutes: 20
     env:
       DERIVED_DATA_PATH: ios/DerivedData
       TEST_RESULT_PATH: ios/TestResults.xcresult
@@ -256,6 +268,9 @@ jobs:
 
       - name: Show Xcode version
         run: xcodebuild -version
+
+      - name: Show Swift version
+        run: swift --version
 
       - name: Setup simulator
         run: bash scripts/ios/setup-simulator.sh
@@ -311,6 +326,11 @@ jobs:
               env_file.write(f"SIMULATOR_NAME={selected['name']}\n")
           PY
 
+      - name: Log available simulators
+        run: |
+          echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] Available iPhone simulators:"
+          xcrun simctl list devices available iPhone || true
+
       - name: Cache DerivedData
         uses: actions/cache@v4
         with:
@@ -323,9 +343,50 @@ jobs:
         run: |
           defaults write com.apple.dt.Xcode IgnoreFileSystemDeviceInodeChanges -bool YES
 
+      - name: Boot simulator (timed)
+        run: |
+          set -euo pipefail
+          log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+          log "Booting simulator $SIMULATOR_NAME ($SIMULATOR_UDID)"
+          start=$(date +%s)
+          xcrun simctl boot "$SIMULATOR_UDID" || true
+          xcrun simctl bootstatus "$SIMULATOR_UDID" -b -s
+          end=$(date +%s)
+          log "Simulator boot ready in $((end - start))s"
+
       - name: Run unit tests
         run: |
-          set -o pipefail && xcodebuild test \
+          set -euo pipefail
+          log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+          if [ ! -d "$DERIVED_DATA_PATH" ]; then
+              log "DerivedData missing; running build-for-testing fallback"
+              xcodebuild build-for-testing \
+                -project ios/Offload.xcodeproj \
+                -scheme offload \
+                -sdk iphonesimulator \
+                -destination "platform=iOS Simulator,id=$SIMULATOR_UDID" \
+                -derivedDataPath "$DERIVED_DATA_PATH" \
+                CODE_SIGN_IDENTITY="" \
+                CODE_SIGNING_REQUIRED=NO \
+                CODE_SIGNING_ALLOWED=NO
+          fi
+
+          watchdog() {
+            while true; do
+              sleep 60
+              log "watchdog: xcodebuild still running"
+              xcrun simctl list devices | grep "$SIMULATOR_UDID" || true
+            done
+          }
+
+          log "Starting tests without rebuild on simulator $SIMULATOR_NAME"
+          start=$(date +%s)
+          watchdog &
+          watchdog_pid=$!
+          trap 'kill "$watchdog_pid" || true' EXIT
+
+          set -o pipefail && xcodebuild test-without-building \
             -project ios/Offload.xcodeproj \
             -scheme offload \
             -sdk iphonesimulator \
@@ -335,7 +396,11 @@ jobs:
             -enableCodeCoverage YES \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO
+            CODE_SIGNING_ALLOWED=NO \
+            -destination-timeout 120
+
+          end=$(date +%s)
+          log "Completed tests in $((end - start))s"
 
       - name: Check coverage threshold
         run: bash scripts/ios/check-coverage.sh "$TEST_RESULT_PATH"

--- a/docs/testing/RCA.md
+++ b/docs/testing/RCA.md
@@ -1,0 +1,26 @@
+<!-- Intent: Document the CI unit test timeout investigation and remediation. -->
+
+# Unit Test CI Timeout RCA
+
+## Summary
+- The "Unit Tests with Coverage" job timed out because `xcodebuild test` rebuilt the entire app and test bundle on a fresh runner, then attempted to run tests and generate coverage, exceeding the 15-minute job cap.
+- The workflow lacked timestamps or watchdog logging, so the stall looked like a hang with no clarity on which phase consumed time.
+
+## Evidence
+- The test job runs on a clean macOS runner and invokes `xcodebuild test`, which performs a full build before running tests. With coverage enabled and no prebuilt artifacts, this duplicated the work already done in the separate build job.
+- The linked failing run shows the `Run unit tests` step running until the 15-minute timeout, confirming the time was spent inside the combined build+test command: https://github.com/Will-Conklin/offload/actions/runs/20659608247/job/59319225198.
+
+## Time breakdown
+- Setup tasks (checkout, Xcode selection, simulator selection) complete before the `Run unit tests` step and did not hit the timeout.
+- At least ~13 minutes elapsed inside `xcodebuild test` (the full 15-minute budget minus short setup), indicating the rebuild+test phase is the bottleneck.
+- Prior to this change there was no per-phase timing, so the updated workflow now emits timestamps for simulator boot, build-for-testing, and test execution, plus a one-minute watchdog heartbeat.
+
+## Fix
+- Build job now uses `xcodebuild build-for-testing` and logs start/end times so we only compile once per pipeline.
+- Test job reuses the cached DerivedData and runs `xcodebuild test-without-building` with a fallback `build-for-testing` only when the cache misses.
+- Added simulator pre-boot timing, environment/version logging, and a watchdog that emits status every minute to surface stalls.
+- Increased the test job timeout to 20 minutes for headroom while the reuse path keeps expected runtime well under that limit.
+
+## Before/after
+- Before: failing run above timed out at 15 minutes during `Run unit tests`.
+- After: the next CI runs will capture durations for each phase via the new logging and are expected to finish under the new timeout by avoiding the second full build.


### PR DESCRIPTION
## Summary
- add timing instrumentation for build, simulator boot, and unit-test execution to expose bottlenecks and watchdog long runs
- reuse the build-for-testing output in the unit-test job via cached DerivedData with a fallback build, and extend the timeout for diagnostics
- document the CI timeout RCA and link the failing run for visibility

## Testing
- ⚠️ `npx markdownlint-cli '**/*.md' --ignore node_modules` *(fails in this environment: npm registry access returned 403)*

## Additional context
- Failing reference run: https://github.com/Will-Conklin/offload/actions/runs/20659608247/job/59319225198
- Labels: ci, bug

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957fabbc6f08330b4b39d02ff87f8db)