### PR TITLE
Improve iOS CI simulator boot and coverage diagnostics

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -111,59 +111,18 @@ jobs:
       - name: List available SDKs
         run: xcodebuild -showsdks
 
-      - name: Setup simulator
-        run: bash scripts/ios/setup-simulator.sh
-
-      - name: Select simulator
+      - name: Simulator diagnostics
         run: |
-          python3 <<'PY'
-          import json
-          import os
-          import subprocess
-          import sys
+          set -euo pipefail
+          xcodebuild -version
+          swift --version
+          xcrun simctl list runtimes
+          xcrun simctl list devicetypes | head -n 100
+          xcrun simctl list devices available
+          xcrun simctl list | sed -n '/== Devices ==/,$p' | head -n 200
 
-          preferred = [
-              "iPhone 16 Pro",
-              "iPhone 16",
-              "iPhone 15 Pro",
-              "iPhone 15",
-              "iPhone 14 Pro",
-              "iPhone 14",
-          ]
-
-          data = json.loads(
-              subprocess.check_output(
-                  ["xcrun", "simctl", "list", "devices", "available", "-j"]
-              )
-          )
-
-          devices = []
-          for runtime_devices in data.get("devices", {}).values():
-              for device in runtime_devices:
-                  if device.get("isAvailable") and device.get("name", "").startswith("iPhone"):
-                      devices.append(device)
-
-          selected = None
-          for name in preferred:
-              for device in devices:
-                  if device.get("name") == name:
-                      selected = device
-                      break
-              if selected:
-                  break
-
-          if not selected and devices:
-              selected = devices[0]
-
-          if not selected:
-              print("No available iPhone simulators found.", file=sys.stderr)
-              sys.exit(1)
-
-          print(f"Selected simulator: {selected['name']} ({selected['udid']})")
-          with open(os.environ["GITHUB_ENV"], "a") as env_file:
-              env_file.write(f"SIMULATOR_UDID={selected['udid']}\n")
-              env_file.write(f"SIMULATOR_NAME={selected['name']}\n")
-          PY
+      - name: Allocate simulator
+        run: bash scripts/ios/allocate-simulator.sh
 
       - name: Show build settings (simulator)
         run: |
@@ -272,59 +231,18 @@ jobs:
       - name: Show Swift version
         run: swift --version
 
-      - name: Setup simulator
-        run: bash scripts/ios/setup-simulator.sh
-
-      - name: Select simulator
+      - name: Simulator diagnostics
         run: |
-          python3 <<'PY'
-          import json
-          import os
-          import subprocess
-          import sys
+          set -euo pipefail
+          xcodebuild -version
+          swift --version
+          xcrun simctl list runtimes
+          xcrun simctl list devicetypes | head -n 100
+          xcrun simctl list devices available
+          xcrun simctl list | sed -n '/== Devices ==/,$p' | head -n 200
 
-          preferred = [
-              "iPhone 16 Pro",
-              "iPhone 16",
-              "iPhone 15 Pro",
-              "iPhone 15",
-              "iPhone 14 Pro",
-              "iPhone 14",
-          ]
-
-          data = json.loads(
-              subprocess.check_output(
-                  ["xcrun", "simctl", "list", "devices", "available", "-j"]
-              )
-          )
-
-          devices = []
-          for runtime_devices in data.get("devices", {}).values():
-              for device in runtime_devices:
-                  if device.get("isAvailable") and device.get("name", "").startswith("iPhone"):
-                      devices.append(device)
-
-          selected = None
-          for name in preferred:
-              for device in devices:
-                  if device.get("name") == name:
-                      selected = device
-                      break
-              if selected:
-                  break
-
-          if not selected and devices:
-              selected = devices[0]
-
-          if not selected:
-              print("No available iPhone simulators found.", file=sys.stderr)
-              sys.exit(1)
-
-          print(f"Selected simulator: {selected['name']} ({selected['udid']})")
-          with open(os.environ["GITHUB_ENV"], "a") as env_file:
-              env_file.write(f"SIMULATOR_UDID={selected['udid']}\n")
-              env_file.write(f"SIMULATOR_NAME={selected['name']}\n")
-          PY
+      - name: Allocate simulator
+        run: bash scripts/ios/allocate-simulator.sh
 
       - name: Log available simulators
         run: |
@@ -344,15 +262,7 @@ jobs:
           defaults write com.apple.dt.Xcode IgnoreFileSystemDeviceInodeChanges -bool YES
 
       - name: Boot simulator (timed)
-        run: |
-          set -euo pipefail
-          log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
-          log "Booting simulator $SIMULATOR_NAME ($SIMULATOR_UDID)"
-          start=$(date +%s)
-          xcrun simctl boot "$SIMULATOR_UDID" || true
-          xcrun simctl bootstatus "$SIMULATOR_UDID" -b -s
-          end=$(date +%s)
-          log "Simulator boot ready in $((end - start))s"
+        run: bash scripts/ios/boot-simulator.sh
 
       - name: Run unit tests
         run: |
@@ -402,8 +312,25 @@ jobs:
           end=$(date +%s)
           log "Completed tests in $((end - start))s"
 
+      - name: Inspect test result bundle
+        id: inspect-xcresult
+        if: always()
+        run: |
+          if [ -d "$TEST_RESULT_PATH" ]; then
+              echo "bundle_present=true" >> "$GITHUB_OUTPUT"
+              du -sh "$TEST_RESULT_PATH" || true
+          else
+              echo "bundle_present=false" >> "$GITHUB_OUTPUT"
+              echo "::error::Test result bundle missing at $TEST_RESULT_PATH (xcodebuild may have failed before writing results)."
+          fi
+
       - name: Check coverage threshold
-        run: bash scripts/ios/check-coverage.sh "$TEST_RESULT_PATH"
+        run: |
+          if [ "${{ steps.inspect-xcresult.outputs.bundle_present }}" != "true" ]; then
+              echo "::error::Cannot check coverage because $TEST_RESULT_PATH is missing. Inspect test logs above for the root cause."
+              exit 1
+          fi
+          bash scripts/ios/check-coverage.sh "$TEST_RESULT_PATH"
 
       - name: Upload test results
         if: always()
@@ -411,11 +338,16 @@ jobs:
         with:
           name: test-results
           path: ${{ env.TEST_RESULT_PATH }}
+          if-no-files-found: warn
           retention-days: 30
 
       - name: Generate coverage report
         if: always()
         run: |
+          if [ "${{ steps.inspect-xcresult.outputs.bundle_present }}" != "true" ]; then
+              echo "Skipping coverage report generation because $TEST_RESULT_PATH is missing."
+              exit 0
+          fi
           xcrun xccov view --report --json "$TEST_RESULT_PATH" > coverage-report.json
 
       - name: Upload coverage report
@@ -424,6 +356,7 @@ jobs:
         with:
           name: coverage-report
           path: coverage-report.json
+          if-no-files-found: warn
           retention-days: 30
 
   # UI Tests - Disabled initially

--- a/docs/ci/RCA.md
+++ b/docs/ci/RCA.md
@@ -1,0 +1,26 @@
+<!-- Intent: Capture RCA for the simulator boot exit 117 and coverage exit 1 failures in iOS CI. -->
+
+# iOS CI Failure RCA (Run 20662961598)
+
+## Summary
+- The **Boot simulator (timed)** step exited with status **117** because `xcrun simctl bootstatus ... -s` only checks state and returns non-zero when the device is not yet booted. The workflow queried status immediately after issuing `simctl boot`, so slower boots caused a non-zero exit without diagnostics. Tests never started, preventing `ios/TestResults.xcresult` from being written.
+- The **Generate coverage report** step failed with exit code **1** because it called `xcrun xccov view --report --json ios/TestResults.xcresult` when that bundle was absent.
+
+## Evidence
+- Workflow commands from `.github/workflows/ios-ci.yml` (pre-fix):
+  - Boot: `xcrun simctl boot "$SIMULATOR_UDID"` then `xcrun simctl bootstatus "$SIMULATOR_UDID" -b -s`.
+  - Tests: `xcodebuild test-without-building ... -resultBundlePath "$TEST_RESULT_PATH" -enableCodeCoverage YES`.
+  - Coverage: `xcrun xccov view --report --json "$TEST_RESULT_PATH"`.
+- Failed job summary included `Boot simulator (timed)` exit code **117** and `Generate coverage report` exit code **1**, and no `ios/TestResults.xcresult` artifact was produced.
+
+## Fix
+- Add full simulator diagnostics (toolchain versions, runtimes, device types, available devices, booted devices) before allocation.
+- Create a fresh simulator via `scripts/ios/allocate-simulator.sh`, selecting the newest available iOS runtime and a preferred iPhone device type.
+- Replace the boot step with `scripts/ios/boot-simulator.sh`, which logs exit codes for `simctl boot` and `simctl bootstatus -b -t 180`, and emits `simctl diagnose` plus `launchd_sim` logs on failure.
+- Gate coverage generation on the presence of `ios/TestResults.xcresult`; emit a clear error when missing and downgrade artifact upload failures to warnings.
+
+## Command Lines (post-fix)
+- Simulator creation: `bash scripts/ios/allocate-simulator.sh` (selects runtime/device and exports `SIMULATOR_UDID`/`SIMULATOR_NAME`).
+- Boot: `bash scripts/ios/boot-simulator.sh` (internally runs `xcrun simctl boot ...` + `xcrun simctl bootstatus ... -b -t 180`).
+- Tests: `xcodebuild test-without-building -project ios/Offload.xcodeproj -scheme offload -sdk iphonesimulator -destination "platform=iOS Simulator,id=$SIMULATOR_UDID" -derivedDataPath ios/DerivedData -resultBundlePath ios/TestResults.xcresult -enableCodeCoverage YES -destination-timeout 120`.
+- Coverage: `xcrun xccov view --report --json ios/TestResults.xcresult` (only when the bundle exists).

--- a/docs/ci/ios-ci-rca.md
+++ b/docs/ci/ios-ci-rca.md
@@ -7,15 +7,11 @@ This document tracks failed GitHub Actions runs, observed symptoms, and fixes
 applied so we do not retry the same changes.
 
 ## Current Status
-- Latest run: 20648070979 (PR #17) failed in "Build iOS App".
-- Symptom: Swift compile errors after selecting Xcode 26.1.1 on the runner:
-  - `HandOffRequest` has no member `brainDumpEntry` in
-    `HandOffRepository.swift` and `SuggestionRepository.swift`.
-  - `modelContext.fetch(descriptor)` fails with
-    "generic parameter 'T' could not be inferred" in `SuggestionRepository.swift`.
-- Fix in progress: Repository lookups now reference `captureEntry` and SwiftData
-  fetches have explicit typing to avoid inference issues. Pending validation in
-  the next CI run on `macos-26`.
+- Latest run: 20662961598 (main) failed in "Unit Tests with Coverage".
+- Symptoms:
+  - `Boot simulator (timed)` exited 117 while using `xcrun simctl bootstatus ... -b -s`.
+  - `Generate coverage report` exited 1 because `ios/TestResults.xcresult` was missing.
+- Fix in progress: Replace simulator selection with fresh allocation + blocking boot, add diagnostics, and gate coverage on xcresult presence.
 
 ## Constraints
 - Local macOS cannot run Xcode 16, so downgrading locally is not viable.
@@ -38,6 +34,7 @@ applied so we do not retry the same changes.
 | 2026-01-01 | b612a13 | Select newest installed Xcode on runner. | Run 20648070979 | Now fails in Swift compilation (no `brainDumpEntry` member). |
 | 2026-01-02 | Pending (this PR) | Use `captureEntry` relationship and typed SwiftData fetches to satisfy Xcode 26.1.1 compiler. | Pending next CI run | Pending |
 | 2026-01-02 | N/A | Switch iOS workflow runners to `macos-26` for Xcode 26.x coverage. | Pending next CI run | Pending validation of simulator availability and build. |
+| 2026-01-02 | Pending (this PR) | Allocate a fresh simulator, add blocking boot with diagnostics, and gate coverage on xcresult presence. | Run 20662961598 | Pending validation (boot returned 117). |
 
 
 ## Additional Findings

--- a/scripts/ios/allocate-simulator.sh
+++ b/scripts/ios/allocate-simulator.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+# Intent: Allocate a fresh iPhone simulator for CI, preferring modern devices and exporting metadata for downstream steps.
+
+set -euo pipefail
+
+echo "=== Allocating simulator for CI ==="
+
+PREFERRED_DEVICES=(
+    "iPhone 16 Pro"
+    "iPhone 16"
+    "iPhone 15 Pro"
+    "iPhone 15"
+    "iPhone 14 Pro"
+    "iPhone 14"
+)
+
+echo "-- Listing runtimes --"
+xcrun simctl list runtimes
+
+echo "-- Listing device types --"
+xcrun simctl list devicetypes | head -n 100
+
+python3 <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+preferred_devices = [
+    "iPhone 16 Pro",
+    "iPhone 16",
+    "iPhone 15 Pro",
+    "iPhone 15",
+    "iPhone 14 Pro",
+    "iPhone 14",
+]
+
+
+def version_tuple(version: str) -> tuple[int, ...]:
+    parts = []
+    current = ""
+    for ch in version:
+        if ch.isdigit():
+            current += ch
+        elif current:
+            parts.append(int(current))
+            current = ""
+    if current:
+        parts.append(int(current))
+    return tuple(parts) or (0,)
+
+
+def run_json(args: list[str]) -> dict:
+    try:
+        raw = subprocess.check_output(args)
+    except subprocess.CalledProcessError as exc:
+        print(f"Command failed: {' '.join(args)}", file=sys.stderr)
+        print(exc, file=sys.stderr)
+        sys.exit(1)
+    return json.loads(raw)
+
+
+runtimes = run_json(["xcrun", "simctl", "list", "runtimes", "-j"]).get(
+    "runtimes", []
+)
+ios_runtimes = [
+    rt
+    for rt in runtimes
+    if rt.get("isAvailable") and "iOS" in rt.get("name", "")
+]
+
+if not ios_runtimes:
+    print("No available iOS runtimes found", file=sys.stderr)
+    sys.exit(1)
+
+ios_runtimes.sort(key=lambda rt: version_tuple(rt.get("version", "0")), reverse=True)
+runtime = ios_runtimes[0]
+
+devicetypes = run_json(["xcrun", "simctl", "list", "devicetypes", "-j"]).get(
+    "devicetypes", []
+)
+
+selected_type = None
+for name in preferred_devices:
+    for dev_type in devicetypes:
+        if dev_type.get("name") == name:
+            selected_type = dev_type
+            break
+    if selected_type:
+        break
+
+if selected_type is None:
+    for dev_type in devicetypes:
+        if "iPhone" in dev_type.get("name", ""):
+            selected_type = dev_type
+            break
+
+if selected_type is None:
+    print("No iPhone device types available", file=sys.stderr)
+    sys.exit(1)
+
+sim_name = f"CI {selected_type['name']} ({runtime['version']})"
+create_cmd = [
+    "xcrun",
+    "simctl",
+    "create",
+    sim_name,
+    selected_type["identifier"],
+    runtime["identifier"],
+]
+
+result = subprocess.run(create_cmd, capture_output=True, text=True)
+if result.returncode != 0:
+    print("Failed to create simulator", file=sys.stderr)
+    print(result.stdout, file=sys.stderr)
+    print(result.stderr, file=sys.stderr)
+    sys.exit(result.returncode)
+
+udid = result.stdout.strip()
+print(f"Selected runtime: {runtime['name']} ({runtime['identifier']})")
+print(f"Selected device type: {selected_type['name']} ({selected_type['identifier']})")
+print(f"Created simulator: {sim_name} ({udid})")
+
+env_path = os.environ.get("GITHUB_ENV")
+for key, value in [
+    ("SIMULATOR_UDID", udid),
+    ("SIMULATOR_NAME", sim_name),
+    ("SIMULATOR_RUNTIME", runtime.get("identifier", "")),
+    ("SIMULATOR_RUNTIME_VERSION", runtime.get("version", "")),
+    ("SIMULATOR_DEVICE_TYPE", selected_type.get("identifier", "")),
+]:
+    line = f"{key}={value}\n"
+    sys.stdout.write(line)
+    if env_path:
+        with open(env_path, "a", encoding="utf-8") as env_file:
+            env_file.write(line)
+PY
+
+echo "-- Listing available devices after creation --"
+xcrun simctl list devices available iPhone || true
+
+exit 0

--- a/scripts/ios/boot-simulator.sh
+++ b/scripts/ios/boot-simulator.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Intent: Boot a CI-created simulator with diagnostics, surfacing exit codes for RCA.
+
+set -euo pipefail
+
+UDID="${SIMULATOR_UDID:-}"
+NAME="${SIMULATOR_NAME:-}"
+
+if [ -z "$UDID" ] || [ -z "$NAME" ]; then
+    echo "❌ SIMULATOR_UDID and SIMULATOR_NAME must be set before booting."
+    exit 1
+fi
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+log "Preparing to boot simulator $NAME ($UDID)"
+
+echo "-- Current simulator state --"
+xcrun simctl list devices "$UDID" || true
+
+start=$(date +%s)
+boot_rc=0
+xcrun simctl boot "$UDID" || boot_rc=$?
+log "simctl boot exit code: $boot_rc"
+
+bootstatus_rc=0
+xcrun simctl bootstatus "$UDID" -b -t 180 || bootstatus_rc=$?
+log "simctl bootstatus exit code: $bootstatus_rc"
+
+if [ "$bootstatus_rc" -ne 0 ]; then
+    log "Bootstatus failed; capturing diagnostics"
+    xcrun simctl list devices "$UDID" || true
+    xcrun simctl diagnose -b || true
+    log "Recent launchd_sim logs:"
+    log show --last 10m --predicate 'process == "launchd_sim"' --style compact || true
+    exit "$bootstatus_rc"
+fi
+
+end=$(date +%s)
+log "Simulator boot ready in $((end - start))s"
+exit 0


### PR DESCRIPTION
## Summary
- add simulator diagnostics + fresh simulator allocation before build and tests
- replace bootstatus polling with a blocking boot script that captures exit codes and `simctl diagnose` output on failure
- gate coverage steps on the presence of `ios/TestResults.xcresult`, with clearer errors and warning-only artifact uploads

## RCA
- Failure in run 20662961598: `Boot simulator (timed)` exited 117 because the workflow called `xcrun simctl bootstatus "$SIMULATOR_UDID" -b -s`, which only reports state and returned non-zero when the simulator had not finished booting; no diagnostics were captured and tests never started, so `ios/TestResults.xcresult` was not produced.
- Coverage then called `xcrun xccov view --report --json ios/TestResults.xcresult` and exited 1 because the bundle was missing.

## Workflow commands
- Boot: `bash scripts/ios/boot-simulator.sh` (runs `xcrun simctl boot "$SIMULATOR_UDID"` and `xcrun simctl bootstatus "$SIMULATOR_UDID" -b -t 180`).
- Tests: `xcodebuild test-without-building -project ios/Offload.xcodeproj -scheme offload -sdk iphonesimulator -destination "platform=iOS Simulator,id=$SIMULATOR_UDID" -derivedDataPath ios/DerivedData -resultBundlePath ios/TestResults.xcresult -enableCodeCoverage YES CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -destination-timeout 120`.
- Coverage: `xcrun xccov view --report --json ios/TestResults.xcresult` (now gated on bundle presence).

## Testing
- markdownlint (fails in this environment: npm registry access returns 403)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69580106c4288330b8a0f7814800152c)