### PR TITLE
Improve CI simulator allocation and boot reliability

### DIFF
--- a/scripts/ios/allocate-simulator.sh
+++ b/scripts/ios/allocate-simulator.sh
@@ -37,6 +37,13 @@ preferred_devices = [
 ]
 
 
+def is_available(device: dict) -> bool:
+    if "isAvailable" in device:
+        return bool(device.get("isAvailable"))
+    availability = str(device.get("availability", "")).lower()
+    return "available" in availability
+
+
 def version_tuple(version: str) -> tuple[int, ...]:
     parts = []
     current = ""
@@ -61,13 +68,11 @@ def run_json(args: list[str]) -> dict:
     return json.loads(raw)
 
 
-runtimes = run_json(["xcrun", "simctl", "list", "runtimes", "-j"]).get(
+raw_runtimes = run_json(["xcrun", "simctl", "list", "runtimes", "-j"]).get(
     "runtimes", []
 )
 ios_runtimes = [
-    rt
-    for rt in runtimes
-    if rt.get("isAvailable") and "iOS" in rt.get("name", "")
+    rt for rt in raw_runtimes if rt.get("isAvailable") and "iOS" in rt.get("name", "")
 ]
 
 if not ios_runtimes:
@@ -77,58 +82,108 @@ if not ios_runtimes:
 ios_runtimes.sort(key=lambda rt: version_tuple(rt.get("version", "0")), reverse=True)
 runtime = ios_runtimes[0]
 
-devicetypes = run_json(["xcrun", "simctl", "list", "devicetypes", "-j"]).get(
-    "devicetypes", []
-)
+devices_by_runtime = run_json(["xcrun", "simctl", "list", "devices", "available", "-j"]).get("devices", {})
+runtime_by_id = {rt["identifier"]: rt for rt in raw_runtimes}
 
-selected_type = None
-for name in preferred_devices:
-    for dev_type in devicetypes:
-        if dev_type.get("name") == name:
-            selected_type = dev_type
+candidates: list[dict] = []
+for runtime_identifier, devices in devices_by_runtime.items():
+    runtime_info = runtime_by_id.get(runtime_identifier) or {}
+    if "iOS" not in runtime_info.get("name", "") or not runtime_info.get("isAvailable"):
+        continue
+    for device in devices:
+        if not is_available(device):
+            continue
+        if "iPhone" not in device.get("name", ""):
+            continue
+        candidates.append(
+            {
+                "name": device.get("name", ""),
+                "udid": device.get("udid", ""),
+                "runtime_identifier": runtime_identifier,
+                "runtime_name": runtime_info.get("name", runtime_identifier),
+                "runtime_version": runtime_info.get("version", "0"),
+                "state": device.get("state", "unknown"),
+                "device_type_identifier": device.get("deviceTypeIdentifier", ""),
+                "is_available": is_available(device),
+            }
+        )
+
+if candidates:
+    def candidate_sort_key(device: dict) -> tuple[int, tuple[int, ...]]:
+        try:
+            preferred_index = preferred_devices.index(device["name"])
+        except ValueError:
+            preferred_index = len(preferred_devices)
+        version_key = tuple(-part for part in version_tuple(device["runtime_version"]))
+        return (preferred_index, version_key)
+
+    candidates.sort(key=candidate_sort_key)
+    selected = candidates[0]
+    udid = selected["udid"]
+    sim_name = selected["name"]
+    runtime_identifier = selected["runtime_identifier"]
+    runtime_version = selected["runtime_version"]
+    runtime_name = selected["runtime_name"]
+    device_type_identifier = selected.get("device_type_identifier") or selected["name"]
+    print("Reusing available simulator:")
+    print(json.dumps(selected, indent=2))
+else:
+    devicetypes = run_json(["xcrun", "simctl", "list", "devicetypes", "-j"]).get(
+        "devicetypes", []
+    )
+
+    selected_type = None
+    for name in preferred_devices:
+        for dev_type in devicetypes:
+            if dev_type.get("name") == name:
+                selected_type = dev_type
+                break
+        if selected_type:
             break
-    if selected_type:
-        break
 
-if selected_type is None:
-    for dev_type in devicetypes:
-        if "iPhone" in dev_type.get("name", ""):
-            selected_type = dev_type
-            break
+    if selected_type is None:
+        for dev_type in devicetypes:
+            if "iPhone" in dev_type.get("name", ""):
+                selected_type = dev_type
+                break
 
-if selected_type is None:
-    print("No iPhone device types available", file=sys.stderr)
-    sys.exit(1)
+    if selected_type is None:
+        print("No iPhone device types available", file=sys.stderr)
+        sys.exit(1)
 
-sim_name = f"CI {selected_type['name']} ({runtime['version']})"
-create_cmd = [
-    "xcrun",
-    "simctl",
-    "create",
-    sim_name,
-    selected_type["identifier"],
-    runtime["identifier"],
-]
+    sim_name = f"CI {selected_type['name']} ({runtime['version']})"
+    create_cmd = [
+        "xcrun",
+        "simctl",
+        "create",
+        sim_name,
+        selected_type["identifier"],
+        runtime["identifier"],
+    ]
 
-result = subprocess.run(create_cmd, capture_output=True, text=True)
-if result.returncode != 0:
-    print("Failed to create simulator", file=sys.stderr)
-    print(result.stdout, file=sys.stderr)
-    print(result.stderr, file=sys.stderr)
-    sys.exit(result.returncode)
+    result = subprocess.run(create_cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print("Failed to create simulator", file=sys.stderr)
+        print(result.stdout, file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(result.returncode)
 
-udid = result.stdout.strip()
-print(f"Selected runtime: {runtime['name']} ({runtime['identifier']})")
-print(f"Selected device type: {selected_type['name']} ({selected_type['identifier']})")
-print(f"Created simulator: {sim_name} ({udid})")
+    udid = result.stdout.strip()
+    runtime_identifier = runtime["identifier"]
+    runtime_version = runtime["version"]
+    runtime_name = runtime["name"]
+    device_type_identifier = selected_type.get("identifier", "")
+    print(f"Selected runtime: {runtime_name} ({runtime_identifier})")
+    print(f"Selected device type: {selected_type['name']} ({selected_type['identifier']})")
+    print(f"Created simulator: {sim_name} ({udid})")
 
 env_path = os.environ.get("GITHUB_ENV")
 for key, value in [
     ("SIMULATOR_UDID", udid),
     ("SIMULATOR_NAME", sim_name),
-    ("SIMULATOR_RUNTIME", runtime.get("identifier", "")),
-    ("SIMULATOR_RUNTIME_VERSION", runtime.get("version", "")),
-    ("SIMULATOR_DEVICE_TYPE", selected_type.get("identifier", "")),
+    ("SIMULATOR_RUNTIME", runtime_identifier),
+    ("SIMULATOR_RUNTIME_VERSION", runtime_version),
+    ("SIMULATOR_DEVICE_TYPE", device_type_identifier),
 ]:
     line = f"{key}={value}\n"
     sys.stdout.write(line)

--- a/scripts/ios/boot-simulator.sh
+++ b/scripts/ios/boot-simulator.sh
@@ -19,24 +19,53 @@ log "Preparing to boot simulator $NAME ($UDID)"
 echo "-- Current simulator state --"
 xcrun simctl list devices "$UDID" || true
 
-start=$(date +%s)
-boot_rc=0
-xcrun simctl boot "$UDID" || boot_rc=$?
-log "simctl boot exit code: $boot_rc"
+attempts=3
+sleep_between=20
+final_rc=1
 
-bootstatus_rc=0
-xcrun simctl bootstatus "$UDID" -b -t 180 || bootstatus_rc=$?
-log "simctl bootstatus exit code: $bootstatus_rc"
-
-if [ "$bootstatus_rc" -ne 0 ]; then
-    log "Bootstatus failed; capturing diagnostics"
+diagnostics() {
+    log "Simulator diagnostics:"
     xcrun simctl list devices "$UDID" || true
-    xcrun simctl diagnose -b || true
-    log "Recent launchd_sim logs:"
-    log show --last 10m --predicate 'process == "launchd_sim"' --style compact || true
-    exit "$bootstatus_rc"
-fi
+    xcrun simctl list devices available iPhone || true
+    xcrun simctl list runtimes || true
+    xcrun simctl getenv "$UDID" HOME || true
+    log "Recent CoreSimulator logs:"
+    log show --last 5m --predicate 'process == "com.apple.CoreSimulator.CoreSimulatorService"' --style compact || true
+}
 
-end=$(date +%s)
-log "Simulator boot ready in $((end - start))s"
-exit 0
+for attempt in $(seq 1 "$attempts"); do
+    log "Boot attempt $attempt/$attempts for $NAME ($UDID)"
+
+    xcrun simctl shutdown "$UDID" || true
+    if [ "$attempt" -gt 1 ]; then
+        log "Erasing simulator to recover from previous failure"
+        xcrun simctl erase "$UDID" || true
+    fi
+
+    start=$(date +%s)
+    boot_rc=0
+    xcrun simctl boot "$UDID" || boot_rc=$?
+    log "simctl boot exit code: $boot_rc"
+
+    bootstatus_rc=0
+    xcrun simctl bootstatus "$UDID" -b -t 300 || bootstatus_rc=$?
+    log "simctl bootstatus exit code: $bootstatus_rc"
+    final_rc=$bootstatus_rc
+
+    if [ "$bootstatus_rc" -eq 0 ]; then
+        end=$(date +%s)
+        log "Simulator boot ready in $((end - start))s"
+        exit 0
+    fi
+
+    diagnostics
+
+    if [ "$attempt" -lt "$attempts" ]; then
+        log "Boot attempt $attempt failed; retrying after backoff (${sleep_between}s)"
+        sleep "$sleep_between"
+    fi
+done
+
+log "All boot attempts failed for $NAME ($UDID)"
+diagnostics
+exit "$final_rc"


### PR DESCRIPTION
## Summary
- select the highest-priority available iPhone simulator from simctl JSON output before creating a new device, exporting its metadata for downstream steps
- add shutdown/erase retries with extended bootstatus wait and high-signal diagnostics (device/runtime lists, CoreSimulator logs) when booting the CI simulator

## Testing
- Not run (CI-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958308abf0c8330b553e62c33c008cd)