### PR TITLE
Improve CI simulator boot reliability

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -163,7 +163,7 @@ jobs:
             -project ios/Offload.xcodeproj \
             -scheme offload \
             -sdk iphonesimulator \
-            -destination "platform=iOS Simulator,id=$SIMULATOR_UDID" \
+            -destination "id=$SIMULATOR_UDID" \
             -derivedDataPath "$DERIVED_DATA_PATH" \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
@@ -261,6 +261,7 @@ jobs:
         run: |
           defaults write com.apple.dt.Xcode IgnoreFileSystemDeviceInodeChanges -bool YES
 
+      # Exit 117 has been observed here when CoreSimulator services are stuck; the boot script now retries with shutdown/erase and prints simulator inventories for RCA.
       - name: Boot simulator (timed)
         run: bash scripts/ios/boot-simulator.sh
 
@@ -275,7 +276,7 @@ jobs:
                 -project ios/Offload.xcodeproj \
                 -scheme offload \
                 -sdk iphonesimulator \
-                -destination "platform=iOS Simulator,id=$SIMULATOR_UDID" \
+                -destination "id=$SIMULATOR_UDID" \
                 -derivedDataPath "$DERIVED_DATA_PATH" \
                 CODE_SIGN_IDENTITY="" \
                 CODE_SIGNING_REQUIRED=NO \
@@ -300,7 +301,7 @@ jobs:
             -project ios/Offload.xcodeproj \
             -scheme offload \
             -sdk iphonesimulator \
-            -destination "platform=iOS Simulator,id=$SIMULATOR_UDID" \
+            -destination "id=$SIMULATOR_UDID" \
             -derivedDataPath "$DERIVED_DATA_PATH" \
             -resultBundlePath "$TEST_RESULT_PATH" \
             -enableCodeCoverage YES \
@@ -316,18 +317,31 @@ jobs:
         id: inspect-xcresult
         if: always()
         run: |
+          set -euo pipefail
           if [ -d "$TEST_RESULT_PATH" ]; then
               echo "bundle_present=true" >> "$GITHUB_OUTPUT"
               du -sh "$TEST_RESULT_PATH" || true
-          else
-              echo "bundle_present=false" >> "$GITHUB_OUTPUT"
-              echo "::error::Test result bundle missing at $TEST_RESULT_PATH (xcodebuild may have failed before writing results)."
+              exit 0
           fi
+
+          echo "bundle_present=false" >> "$GITHUB_OUTPUT"
+          echo "::error::Test result bundle missing at $TEST_RESULT_PATH. Simulator boot likely failed before tests ran; collecting diagnostics."
+
+          echo "== Post-failure simulator diagnostics =="
+          xcrun simctl list devices available || true
+          xcrun simctl list runtimes || true
+          if [ -n "${SIMULATOR_UDID:-}" ]; then
+              xcrun simctl list devices "$SIMULATOR_UDID" || true
+              xcrun simctl getenv "$SIMULATOR_UDID" SIMULATOR_DEVICE_NAME || true
+              xcrun simctl spawn "$SIMULATOR_UDID" launchctl print system || true
+          fi
+
+          exit 1
 
       - name: Check coverage threshold
         run: |
           if [ "${{ steps.inspect-xcresult.outputs.bundle_present }}" != "true" ]; then
-              echo "::error::Cannot check coverage because $TEST_RESULT_PATH is missing. Inspect test logs above for the root cause."
+              echo "::error::Cannot check coverage because $TEST_RESULT_PATH is missing. Simulator boot failures prevent xcodebuild from writing results; see diagnostics above."
               exit 1
           fi
           bash scripts/ios/check-coverage.sh "$TEST_RESULT_PATH"

--- a/scripts/ios/boot-simulator.sh
+++ b/scripts/ios/boot-simulator.sh
@@ -1,37 +1,142 @@
 #!/bin/bash
 
-# Intent: Boot a CI-created simulator with diagnostics, surfacing exit codes for RCA.
+# Intent: Boot a CI-created simulator deterministically with retries, defensive cleanup, and high-signal diagnostics.
 
 set -euo pipefail
 
-UDID="${SIMULATOR_UDID:-}"
-NAME="${SIMULATOR_NAME:-}"
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+resolve_device_json=$(
+python3 <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+preferred_udid = os.environ.get("SIMULATOR_UDID", "").strip()
+
+
+def version_tuple(version: str) -> tuple[int, ...]:
+    parts = []
+    current = ""
+    for ch in version:
+        if ch.isdigit():
+            current += ch
+        elif current:
+            parts.append(int(current))
+            current = ""
+    if current:
+        parts.append(int(current))
+    return tuple(parts) or (0,)
+
+
+def load_json(args: list[str]) -> dict:
+    try:
+        raw = subprocess.check_output(args)
+    except subprocess.CalledProcessError as exc:
+        print(f"Command failed: {' '.join(args)}", file=sys.stderr)
+        print(exc, file=sys.stderr)
+        sys.exit(1)
+    return json.loads(raw)
+
+
+runtimes = load_json(["xcrun", "simctl", "list", "runtimes", "-j"]).get("runtimes", [])
+available_runtimes = {rt["identifier"]: rt for rt in runtimes if rt.get("isAvailable")}
+available_devices = load_json(
+    ["xcrun", "simctl", "list", "devices", "available", "-j"]
+).get("devices", {})
+
+selected = None
+if preferred_udid:
+    for runtime_identifier, devices in available_devices.items():
+        runtime = available_runtimes.get(runtime_identifier)
+        if not runtime or "iOS" not in runtime.get("name", ""):
+            continue
+        for device in devices:
+            if device.get("udid") == preferred_udid and device.get("isAvailable", False):
+                selected = {
+                    "udid": device.get("udid", ""),
+                    "name": device.get("name", ""),
+                    "runtime_identifier": runtime_identifier,
+                    "runtime_name": runtime.get("name", ""),
+                    "runtime_version": runtime.get("version", "0"),
+                    "state": device.get("state", "unknown"),
+                }
+                break
+        if selected:
+            break
+
+if not selected:
+    candidates = []
+    for runtime_identifier, devices in available_devices.items():
+        runtime = available_runtimes.get(runtime_identifier)
+        if not runtime or "iOS" not in runtime.get("name", ""):
+            continue
+        for device in devices:
+            if not device.get("isAvailable", False):
+                continue
+            if "iPhone" not in device.get("name", ""):
+                continue
+            candidates.append(
+                {
+                    "udid": device.get("udid", ""),
+                    "name": device.get("name", ""),
+                    "runtime_identifier": runtime_identifier,
+                    "runtime_name": runtime.get("name", ""),
+                    "runtime_version": runtime.get("version", "0"),
+                    "state": device.get("state", "unknown"),
+                }
+            )
+    if not candidates:
+        print("No available iPhone simulators found.", file=sys.stderr)
+        sys.exit(1)
+    candidates.sort(key=lambda dev: tuple(-part for part in version_tuple(dev["runtime_version"])))
+    selected = candidates[0]
+
+print(json.dumps(selected))
+PY
+)
+
+UDID="$(echo "$resolve_device_json" | python3 -c "import json,sys;print(json.load(sys.stdin)['udid'])")"
+NAME="$(echo "$resolve_device_json" | python3 -c "import json,sys;print(json.load(sys.stdin)['name'])")"
+RUNTIME_NAME="$(echo "$resolve_device_json" | python3 -c "import json,sys;print(json.load(sys.stdin)['runtime_name'])")"
+RUNTIME_VERSION="$(echo "$resolve_device_json" | python3 -c "import json,sys;print(json.load(sys.stdin)['runtime_version'])")"
 
 if [ -z "$UDID" ] || [ -z "$NAME" ]; then
-    echo "❌ SIMULATOR_UDID and SIMULATOR_NAME must be set before booting."
+    echo "❌ Unable to resolve an available simulator UDID."
     exit 1
 fi
 
-log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+if [ -n "${GITHUB_ENV:-}" ]; then
+    {
+        echo "SIMULATOR_UDID=$UDID"
+        echo "SIMULATOR_NAME=$NAME"
+    } >> "$GITHUB_ENV"
+fi
 
-log "Preparing to boot simulator $NAME ($UDID)"
+log "Preparing to boot simulator $NAME ($UDID) on runtime $RUNTIME_NAME $RUNTIME_VERSION"
 
-echo "-- Current simulator state --"
-xcrun simctl list devices "$UDID" || true
+diagnostics() {
+    log "Simulator diagnostics (UDID=$UDID):"
+    xcrun simctl list devices "$UDID" || true
+    xcrun simctl list devices available || true
+    xcrun simctl list runtimes || true
+    xcrun simctl getenv "$UDID" SIMULATOR_DEVICE_NAME || true
+    xcrun simctl spawn "$UDID" launchctl print system || true
+    log "Recent CoreSimulator logs:"
+    log show --last 5m --predicate 'process == "com.apple.CoreSimulator.CoreSimulatorService"' --style compact || true
+}
+
+log "Resetting CoreSimulator services before boot"
+killall Simulator || true
+killall -9 com.apple.CoreSimulator.CoreSimulatorService || true
 
 attempts=3
 sleep_between=20
 final_rc=1
 
-diagnostics() {
-    log "Simulator diagnostics:"
-    xcrun simctl list devices "$UDID" || true
-    xcrun simctl list devices available iPhone || true
-    xcrun simctl list runtimes || true
-    xcrun simctl getenv "$UDID" HOME || true
-    log "Recent CoreSimulator logs:"
-    log show --last 5m --predicate 'process == "com.apple.CoreSimulator.CoreSimulatorService"' --style compact || true
-}
+echo "-- Current simulator state --"
+xcrun simctl list devices "$UDID" || true
 
 for attempt in $(seq 1 "$attempts"); do
     log "Boot attempt $attempt/$attempts for $NAME ($UDID)"


### PR DESCRIPTION
## Summary
- harden simulator boot scripting with available-device selection, service resets, retries, and richer diagnostics
- use UDID-only destinations for xcodebuild and document the prior exit 117 failure point in the workflow
- add post-failure simulator diagnostics when test result bundles are missing to clarify coverage upload failures

## Testing
- Not run (CI environment only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958382f0f30833089b476723376002d)