### PR TITLE
Add deterministic iOS CI scripts

### DIFF
--- a/scripts/ios/build.sh
+++ b/scripts/ios/build.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Intent: Deterministically build the Offload iOS app for CI with stable paths and simulator targets.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+PROJECT_PATH="${PROJECT_PATH:-${REPO_ROOT}/ios/Offload.xcodeproj}"
+SCHEME="${SCHEME:-Offload}"
+CONFIGURATION="${CONFIGURATION:-Debug}"
+DEVICE_NAME="${DEVICE_NAME:-iPhone 15}"
+OS_VERSION="${OS_VERSION:-17.5}"
+DESTINATION="${DESTINATION:-platform=iOS Simulator,name=${DEVICE_NAME},OS=${OS_VERSION}}"
+DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-${REPO_ROOT}/.ci/DerivedData}"
+
+info() {
+  echo "[INFO] $*"
+}
+
+main() {
+  "${SCRIPT_DIR}/preflight.sh"
+
+  mkdir -p "${DERIVED_DATA_PATH}"
+
+  info "Building scheme '${SCHEME}' with configuration '${CONFIGURATION}'."
+  info "DerivedData: ${DERIVED_DATA_PATH}"
+  info "Destination: ${DESTINATION}"
+
+  xcodebuild \
+    -project "${PROJECT_PATH}" \
+    -scheme "${SCHEME}" \
+    -configuration "${CONFIGURATION}" \
+    -destination "${DESTINATION}" \
+    -derivedDataPath "${DERIVED_DATA_PATH}" \
+    COMPILER_INDEX_STORE_ENABLE=NO \
+    build
+}
+
+main "$@"

--- a/scripts/ios/env-report.sh
+++ b/scripts/ios/env-report.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Intent: Summarize iOS CI environment settings, tooling, and destinations for quick diagnostics.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+PROJECT_PATH="${PROJECT_PATH:-${REPO_ROOT}/ios/Offload.xcodeproj}"
+SCHEME="${SCHEME:-Offload}"
+DEVICE_NAME="${DEVICE_NAME:-iPhone 15}"
+OS_VERSION="${OS_VERSION:-17.5}"
+DESTINATION="${DESTINATION:-platform=iOS Simulator,name=${DEVICE_NAME},OS=${OS_VERSION}}"
+DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-${REPO_ROOT}/.ci/DerivedData}"
+RESULT_BUNDLE_PATH="${RESULT_BUNDLE_PATH:-${REPO_ROOT}/.ci/TestResults.xcresult}"
+
+info() {
+  echo "[INFO] $*"
+}
+
+print_versions() {
+  info "xcodebuild version:"
+  if ! xcodebuild -version; then
+    echo "[WARN] Unable to read xcodebuild version. Is Xcode installed?" >&2
+  fi
+
+  if command -v sw_vers >/dev/null 2>&1; then
+    info "macOS version:"
+    sw_vers
+  else
+    echo "[WARN] sw_vers not available (expected on macOS)." >&2
+  fi
+}
+
+main() {
+  info "Project: ${PROJECT_PATH}"
+  info "Scheme: ${SCHEME}"
+  info "Destination: ${DESTINATION}"
+  info "DerivedData: ${DERIVED_DATA_PATH}"
+  info "Result bundle path: ${RESULT_BUNDLE_PATH}"
+
+  print_versions
+
+  info "Available destinations (filtered):"
+  if xcodebuild -showdestinations -project "${PROJECT_PATH}" -scheme "${SCHEME}" 2>/dev/null | grep -E "iOS Simulator" | sed 's/^/  /'; then
+    :
+  else
+    echo "[WARN] Unable to list destinations; ensure Xcode and simulators are installed." >&2
+  fi
+}
+
+main "$@"

--- a/scripts/ios/preflight.sh
+++ b/scripts/ios/preflight.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Intent: Validate iOS CI readiness by checking tooling, scheme availability, and simulator destinations.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+PROJECT_PATH="${PROJECT_PATH:-${REPO_ROOT}/ios/Offload.xcodeproj}"
+SCHEME="${SCHEME:-Offload}"
+DEVICE_NAME="${DEVICE_NAME:-iPhone 15}"
+OS_VERSION="${OS_VERSION:-17.5}"
+DESTINATION="${DESTINATION:-platform=iOS Simulator,name=${DEVICE_NAME},OS=${OS_VERSION}}"
+
+err() {
+  echo "[ERROR] $*" >&2
+}
+
+info() {
+  echo "[INFO] $*"
+}
+
+require_command() {
+  local command_name=$1
+  local install_hint=$2
+
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    err "Missing required command: ${command_name}"
+    err "Install hint: ${install_hint}"
+    exit 1
+  fi
+}
+
+assert_scheme_exists() {
+  local list_output
+  if ! list_output="$(xcodebuild -list -project "${PROJECT_PATH}" 2>&1)"; then
+    err "Unable to list schemes for ${PROJECT_PATH}"
+    err "${list_output}"
+    exit 1
+  fi
+
+  if ! printf "%s\n" "${list_output}" | grep -Eq "^[[:space:]]*${SCHEME}[[:space:]]*$"; then
+    err "Scheme '${SCHEME}' not found in ${PROJECT_PATH}."
+    err "Available schemes:"
+    printf "%s\n" "${list_output}" | awk '/Schemes:/{flag=1;next}/^[[:space:]]*$/{flag=0}flag {print "  - "$0}'
+    err "If the scheme is new, open Xcode and share it or set SCHEME=YourScheme."
+    exit 1
+  fi
+}
+
+assert_destination_available() {
+  local destinations_output=""
+  local destinations_status=0
+
+  if ! destinations_output="$(xcodebuild -showdestinations -project "${PROJECT_PATH}" -scheme "${SCHEME}" 2>&1)"; then
+    destinations_status=$?
+  fi
+
+  if [[ ${destinations_status} -ne 0 ]]; then
+    err "Unable to query destinations with xcodebuild:"
+    err "${destinations_output}"
+    err "Fallback: ensure simulators are installed via Xcode > Settings > Platforms."
+    exit 1
+  fi
+
+  if printf "%s\n" "${destinations_output}" | grep -Eq "name:${DEVICE_NAME}.*,.*OS: ?${OS_VERSION}"; then
+    return 0
+  fi
+
+  err "Destination not found for ${DESTINATION}"
+  err "Try installing the simulator (Xcode > Settings > Platforms) or update DEVICE_NAME/OS_VERSION."
+  err "Available destinations:"
+  printf "%s\n" "${destinations_output}" | sed 's/^/  /'
+  exit 1
+}
+
+main() {
+  info "Project: ${PROJECT_PATH}"
+  info "Scheme: ${SCHEME}"
+  info "Destination: ${DESTINATION}"
+
+  require_command "xcodebuild" "Install Xcode: https://developer.apple.com/xcode/ or run 'xcode-select --install'."
+
+  assert_scheme_exists
+  assert_destination_available
+
+  info "Preflight checks passed."
+}
+
+main "$@"

--- a/scripts/ios/test.sh
+++ b/scripts/ios/test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Intent: Run deterministic iOS simulator tests with explicit destinations and captured result bundles.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+PROJECT_PATH="${PROJECT_PATH:-${REPO_ROOT}/ios/Offload.xcodeproj}"
+SCHEME="${SCHEME:-Offload}"
+CONFIGURATION="${CONFIGURATION:-Debug}"
+DEVICE_NAME="${DEVICE_NAME:-iPhone 15}"
+OS_VERSION="${OS_VERSION:-17.5}"
+DESTINATION="${DESTINATION:-platform=iOS Simulator,name=${DEVICE_NAME},OS=${OS_VERSION}}"
+DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-${REPO_ROOT}/.ci/DerivedData}"
+RESULT_BUNDLE_PATH="${RESULT_BUNDLE_PATH:-${REPO_ROOT}/.ci/TestResults.xcresult}"
+
+info() {
+  echo "[INFO] $*"
+}
+
+warn() {
+  echo "[WARN] $*" >&2
+}
+
+print_versions() {
+  info "xcodebuild version:"
+  xcodebuild -version || warn "Unable to read xcodebuild version."
+
+  if command -v sw_vers >/dev/null 2>&1; then
+    info "macOS version:"
+    sw_vers
+  else
+    warn "sw_vers not available (expected on macOS)."
+  fi
+}
+
+main() {
+  print_versions
+  "${SCRIPT_DIR}/preflight.sh"
+
+  mkdir -p "$(dirname "${RESULT_BUNDLE_PATH}")"
+  rm -rf "${RESULT_BUNDLE_PATH}"
+  mkdir -p "${DERIVED_DATA_PATH}"
+
+  info "Testing scheme '${SCHEME}' on '${DESTINATION}'."
+  info "Result bundle: ${RESULT_BUNDLE_PATH}"
+  info "DerivedData: ${DERIVED_DATA_PATH}"
+
+  set +e
+  xcodebuild \
+    -project "${PROJECT_PATH}" \
+    -scheme "${SCHEME}" \
+    -configuration "${CONFIGURATION}" \
+    -destination "${DESTINATION}" \
+    -derivedDataPath "${DERIVED_DATA_PATH}" \
+    -resultBundlePath "${RESULT_BUNDLE_PATH}" \
+    COMPILER_INDEX_STORE_ENABLE=NO \
+    test
+  status=$?
+  set -e
+
+  if [[ -d "${RESULT_BUNDLE_PATH}" ]]; then
+    info "Result bundle saved to ${RESULT_BUNDLE_PATH}"
+  else
+    warn "Result bundle not found at ${RESULT_BUNDLE_PATH}"
+  fi
+
+  exit "${status}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add deterministic iOS preflight, build, and test scripts with configurable simulator destinations
- include stable DerivedData/result bundle paths and disable index store for CI builds
- provide env-report helper to surface configuration and tooling versions

## Testing
- bash -n scripts/ios/preflight.sh scripts/ios/build.sh scripts/ios/test.sh scripts/ios/env-report.sh

## Labels
- ci
- automation

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958562367288330b1a6d70feb5b40f7)