### PR TITLE
Clarify markdownlint guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ iOS application built with SwiftUI and SwiftData, targeting iPhone and iPad.
 - ALWAYS clean up merged branches.
 - ALWAYS label pull requests with appropriate labels (bug, enhancement, documentation, etc.).
 - ALWAYS keep documentation up to date.
-- ALWAYS run markdownlint prior to committing documentation.
+- ALWAYS run markdownlint prior to committing documentation changes (no need to rerun after every edit).
 - DO NOT make README a changelog.  While in development, PR history can be used to track changes, release notes will be used after initial v1 release.
 
 ## Implementation Plans


### PR DESCRIPTION
## Summary
- clarify that markdownlint should be run before committing documentation changes rather than after every edit

## Testing
- npx --yes markdownlint AGENTS.md (fails: npm 403 fetching markdownlint)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69585abea9648330b7c9216a0763b44c)