### PR TITLE
Add minimal iOS tests-only workflow

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -1,0 +1,106 @@
+# Intent: Minimal iOS tests-only workflow pinned to documented CI values, running preflight and tests while always collecting diagnostics artifacts.
+
+name: iOS Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  bootstrap:
+    name: Read pinned CI environment
+    runs-on: macos-14
+    outputs:
+      macos_runner: ${{ steps.read_env.outputs.macos_runner }}
+      xcode_version: ${{ steps.read_env.outputs.xcode_version }}
+      sim_device: ${{ steps.read_env.outputs.sim_device }}
+      sim_os: ${{ steps.read_env.outputs.sim_os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Parse pinned CI environment
+        id: read_env
+        run: |
+          bash scripts/ci/readiness_env.sh
+          echo "macos_runner=${CI_MACOS_RUNNER}" >> "$GITHUB_OUTPUT"
+          echo "xcode_version=${CI_XCODE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "sim_device=${CI_SIM_DEVICE}" >> "$GITHUB_OUTPUT"
+          echo "sim_os=${CI_SIM_OS}" >> "$GITHUB_OUTPUT"
+
+  tests:
+    name: Test with pinned environment
+    needs: bootstrap
+    runs-on: ${{ needs.bootstrap.outputs.macos_runner }}
+    env:
+      CI_MACOS_RUNNER: ${{ needs.bootstrap.outputs.macos_runner }}
+      CI_XCODE_VERSION: ${{ needs.bootstrap.outputs.xcode_version }}
+      CI_SIM_DEVICE: ${{ needs.bootstrap.outputs.sim_device }}
+      CI_SIM_OS: ${{ needs.bootstrap.outputs.sim_os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Parse pinned CI environment
+        run: bash scripts/ci/readiness_env.sh
+
+      - name: Print pinned values
+        run: |
+          echo "Pinned values from docs/ci/ci-readiness.md:" \
+            "CI_MACOS_RUNNER=${CI_MACOS_RUNNER}" \
+            "CI_XCODE_VERSION=${CI_XCODE_VERSION}" \
+            "CI_SIM_DEVICE=${CI_SIM_DEVICE}" \
+            "CI_SIM_OS=${CI_SIM_OS}"
+
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ needs.bootstrap.outputs.xcode_version }}
+
+      - name: Show runner versions
+        run: |
+          sw_vers
+          xcodebuild -version
+
+      - name: Preflight
+        run: scripts/ios/preflight.sh
+
+      - name: Test
+        env:
+          DEVICE_NAME: ${{ env.CI_SIM_DEVICE }}
+          OS_VERSION: ${{ env.CI_SIM_OS }}
+        run: scripts/ios/test.sh
+
+      - name: Write diagnostics report
+        if: ${{ always() }}
+        run: |
+          mkdir -p .ci
+          {
+            echo "CI_MACOS_RUNNER=${CI_MACOS_RUNNER}";
+            echo "CI_XCODE_VERSION=${CI_XCODE_VERSION}";
+            echo "CI_SIM_DEVICE=${CI_SIM_DEVICE}";
+            echo "CI_SIM_OS=${CI_SIM_OS}";
+            echo "";
+            echo "sw_vers:";
+            sw_vers || true;
+            echo "";
+            echo "xcodebuild -version:";
+            xcodebuild -version || true;
+          } > .ci/env-report.txt
+
+      - name: Upload test results
+        if: ${{ always() && hashFiles('.ci/TestResults.xcresult/**') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-test-results
+          path: .ci/TestResults.xcresult
+          if-no-files-found: ignore
+
+      - name: Upload diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-test-env-report
+          path: .ci/env-report.txt
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- add a tests-only GitHub Actions workflow that is triggered on pushes to main and pull requests
- pin the runner and Xcode version using the documented CI environment values and run preflight plus test scripts
- always collect diagnostics artifacts including env report and any produced xcresult bundle

## Testing
- not run (workflow changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958791fe0e08330b12db4f33fe7ecf2)