### PR TITLE
Add robust simulator allocation and boot hardening scripts for CI

### DIFF
--- a/scripts/ios/allocate-simulator.sh
+++ b/scripts/ios/allocate-simulator.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Intent: Allocate a deterministic available simulator UDID matching preferred name/runtime for CI workflows.
+
+set -euo pipefail
+
+PREFERRED_DEVICE_NAME="${DEVICE_NAME:-${PREFERRED_DEVICE_NAME:-iPhone 15}}"
+PREFERRED_RUNTIME="${OS_VERSION:-${PREFERRED_RUNTIME:-}}"
+PREFERRED_RUNTIME_IDENTIFIER="${SIM_RUNTIME_IDENTIFIER:-${SIM_RUNTIME:-${PREFERRED_RUNTIME_IDENTIFIER:-}}}"
+
+info() {
+  echo "[INFO] $*" >&2
+}
+
+warn() {
+  echo "[WARN] $*" >&2
+}
+
+select_simulator() {
+  python3 - <<'PY'
+import json
+import os
+import sys
+import traceback
+
+preferred_name = os.environ.get("PREFERRED_DEVICE_NAME", "").strip()
+preferred_runtime = os.environ.get("PREFERRED_RUNTIME", "").strip()
+preferred_runtime_id = os.environ.get("PREFERRED_RUNTIME_IDENTIFIER", "").strip()
+
+try:
+    data = json.load(sys.stdin)
+    devices = data.get("devices", {})
+except Exception:
+    traceback.print_exc()
+    sys.exit(1)
+
+def runtime_score(runtime_identifier: str) -> int:
+    if preferred_runtime_id:
+        return 0 if runtime_identifier == preferred_runtime_id else 2
+    if preferred_runtime:
+        normalized = "".join(ch if ch.isalnum() else "-" for ch in preferred_runtime).lower()
+        return 0 if normalized and normalized in runtime_identifier.lower() else 1
+    return 1
+
+def name_score(device_name: str) -> int:
+    if preferred_name:
+        if device_name.lower() == preferred_name.lower():
+            return 0
+        if preferred_name.lower() in device_name.lower():
+            return 1
+    return 2
+
+candidates = []
+
+for runtime_identifier in sorted(devices.keys()):
+    for device in devices.get(runtime_identifier, []):
+        if not device.get("isAvailable", False):
+            continue
+        udid = device.get("udid")
+        name = device.get("name", "")
+        if not udid:
+            continue
+
+        score = (
+            runtime_score(runtime_identifier),
+            name_score(name),
+            runtime_identifier,
+            name,
+            udid,
+        )
+        candidates.append((score, runtime_identifier, name, udid))
+
+if not candidates:
+    print("No available simulators found.", file=sys.stderr)
+    sys.exit(1)
+
+candidates.sort(key=lambda entry: entry[0])
+_, runtime_identifier, name, udid = candidates[0]
+
+print(f"Selected simulator: {name} ({runtime_identifier}) [{udid}]", file=sys.stderr)
+print(udid)
+PY
+}
+
+main() {
+  info "Selecting available simulator matching name='${PREFERRED_DEVICE_NAME}' runtime='${PREFERRED_RUNTIME_IDENTIFIER:-${PREFERRED_RUNTIME}}'"
+
+  if ! output="$(xcrun simctl list -j devices available | select_simulator)"; then
+    warn "Failed to select simulator."
+    exit 1
+  fi
+
+  # output contains stderr logs + UDID; last line is UDID
+  udid="$(printf "%s\n" "${output}" | tail -n 1)"
+  printf "%s\n" "${udid}"
+}
+
+main "$@"

--- a/scripts/ios/boot-simulator.sh
+++ b/scripts/ios/boot-simulator.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Intent: Reliably boot a simulator UDID with retries, cleanup, and diagnostics to reduce CI flakiness.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+UDID="${1:-}"
+BOOT_TIMEOUT="${BOOT_TIMEOUT:-240}"
+MAX_RETRIES="${MAX_BOOT_RETRIES:-3}"
+
+if [[ -z "${UDID}" ]]; then
+  echo "Usage: ${0} <simulator-udid>" >&2
+  exit 1
+fi
+
+info() {
+  echo "[INFO] $*" >&2
+}
+
+warn() {
+  echo "[WARN] $*" >&2
+}
+
+diagnostics() {
+  warn "Boot diagnostics for ${UDID}:"
+  {
+    echo "=== Simulator Runtimes ==="
+    xcrun simctl list runtimes
+    echo
+    echo "=== Simulator Devices ==="
+    xcrun simctl list devices
+  } >&2
+
+  if command -v xcrun >/dev/null 2>&1; then
+    warn "simctl diagnose (best-effort):"
+    if ! xcrun simctl diagnose >&2; then
+      warn "simctl diagnose failed; continuing."
+    fi
+  fi
+}
+
+shutdown_device() {
+  xcrun simctl shutdown "${UDID}" >/dev/null 2>&1 || true
+}
+
+erase_device() {
+  if ! xcrun simctl erase "${UDID}" >/dev/null 2>&1; then
+    warn "Erase failed for ${UDID}; continuing."
+  fi
+}
+
+boot_once() {
+  shutdown_device
+  xcrun simctl boot "${UDID}"
+  xcrun simctl bootstatus "${UDID}" -b -t "${BOOT_TIMEOUT}"
+}
+
+main() {
+  info "Booting simulator ${UDID} with timeout ${BOOT_TIMEOUT}s (max ${MAX_RETRIES} attempts)."
+
+  local attempt=1
+  while (( attempt <= MAX_RETRIES )); do
+    info "Boot attempt ${attempt}/${MAX_RETRIES} for ${UDID}"
+    if boot_once; then
+      info "Simulator ${UDID} booted successfully."
+      return 0
+    fi
+
+    warn "Simulator boot attempt ${attempt} failed for ${UDID}. Retrying with cleanup."
+    (( attempt++ ))
+    shutdown_device
+    erase_device
+  done
+
+  diagnostics
+  warn "All boot attempts failed for ${UDID}."
+  exit 1
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a simulator allocator that prefers the requested device/runtime using `simctl list` JSON output
- add a boot helper with retries, cleanup, and diagnostics for simulator stability
- allow `scripts/ios/test.sh` to allocate and boot a UDID destination before running xcodebuild when enabled

## Testing
- bash -n scripts/ios/allocate-simulator.sh scripts/ios/boot-simulator.sh scripts/ios/test.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69587aad92b083308ba75491ff5819e6)