### PR TITLE
Add non-blocking iOS coverage reports

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -72,6 +72,11 @@ jobs:
           OS_VERSION: ${{ env.CI_SIM_OS }}
         run: scripts/ios/test.sh
 
+      - name: Coverage (non-blocking)
+        if: ${{ always() }}
+        continue-on-error: true
+        run: scripts/ios/coverage.sh
+
       - name: Write diagnostics report
         if: ${{ always() }}
         run: |
@@ -95,6 +100,14 @@ jobs:
         with:
           name: ios-test-results
           path: .ci/TestResults.xcresult
+          if-no-files-found: ignore
+
+      - name: Upload coverage
+        if: ${{ always() && hashFiles('.ci/coverage/**') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-test-coverage
+          path: .ci/coverage
           if-no-files-found: ignore
 
       - name: Upload diagnostics

--- a/scripts/ios/coverage.sh
+++ b/scripts/ios/coverage.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Intent: Generate iOS code coverage reports from existing test result bundles without blocking CI when unavailable.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+RESULT_BUNDLE_PATH="${RESULT_BUNDLE_PATH:-${REPO_ROOT}/.ci/TestResults.xcresult}"
+COVERAGE_DIR="${COVERAGE_DIR:-${REPO_ROOT}/.ci/coverage}"
+COVERAGE_JSON="${COVERAGE_JSON:-${COVERAGE_DIR}/coverage.json}"
+COVERAGE_TXT="${COVERAGE_TXT:-${COVERAGE_DIR}/coverage.txt}"
+
+info() {
+  echo "[INFO] $*"
+}
+
+warn() {
+  echo "[WARN] $*" >&2
+}
+
+main() {
+  if [[ ! -d "${RESULT_BUNDLE_PATH}" ]]; then
+    warn "Result bundle not found at ${RESULT_BUNDLE_PATH}. Skipping coverage generation."
+    exit 0
+  fi
+
+  if ! command -v xcrun >/dev/null 2>&1; then
+    warn "xcrun not available. Skipping coverage generation."
+    exit 0
+  fi
+
+  mkdir -p "${COVERAGE_DIR}"
+
+  info "Generating coverage report from ${RESULT_BUNDLE_PATH}."
+
+  if ! xcrun xccov view --report --json "${RESULT_BUNDLE_PATH}" >"${COVERAGE_JSON}"; then
+    warn "Failed to write JSON coverage report to ${COVERAGE_JSON}."
+    exit 1
+  fi
+
+  if ! xcrun xccov view --report "${RESULT_BUNDLE_PATH}" >"${COVERAGE_TXT}"; then
+    warn "Failed to write text coverage report to ${COVERAGE_TXT}."
+    exit 1
+  fi
+
+  info "Coverage reports saved to ${COVERAGE_DIR}."
+  info "Coverage summary:"
+  cat "${COVERAGE_TXT}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a gated coverage generation script that skips cleanly when test results are unavailable
- run the coverage script in the iOS tests workflow without blocking the job and only upload artifacts when produced

## Testing
- not run (CI only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69587ca51cc08330aac2f41139845311)