### PR TITLE
Update CI simulator runtime pin for Xcode 16.2

### DIFF
--- a/docs/ci/ci-readiness.md
+++ b/docs/ci/ci-readiness.md
@@ -12,9 +12,11 @@
 CI_MACOS_RUNNER: macos-14
 CI_XCODE_VERSION: 16.2
 CI_SIM_DEVICE: iPhone 15
-CI_SIM_OS: 17.5
+CI_SIM_OS: 18.2
 
 > Note: macos-14 GitHub runners no longer provide Xcode 16.0; they ship Xcode 16.2+. Pin CI_XCODE_VERSION to 16.2 to avoid resolution failures.
+
+On macos-14 runners with Xcode 16.2, `xcrun simctl list runtimes` exposes the iOS 18.2 runtime, and `xcrun simctl list devices iOS 18.2` includes an **iPhone 15** simulator. Pinning the destination to that pairing prevents `xcodebuild` from falling back to “latest”.
 
 ## Local build and test commands (xcodebuild)
 Use the project file directly with the shared `offload` scheme.
@@ -24,14 +26,14 @@ Use the project file directly with the shared `offload` scheme.
 xcodebuild \
   -project ios/Offload.xcodeproj \
   -scheme offload \
-  -destination "platform=iOS Simulator,name=iPhone 15" \
+  -destination "platform=iOS Simulator,name=iPhone 15,OS=18.2" \
   clean build
 
 # Run unit and UI tests (code coverage optional)
 xcodebuild \
   -project ios/Offload.xcodeproj \
   -scheme offload \
-  -destination "platform=iOS Simulator,name=iPhone 15" \
+  -destination "platform=iOS Simulator,name=iPhone 15,OS=18.2" \
   -enableCodeCoverage YES \
   test
 ```


### PR DESCRIPTION
## Summary
- align CI_SIM_OS with the installed iOS 18.2 runtime available on macos-14 runners with Xcode 16.2
- document the matching iPhone 15 simulator pairing to avoid destination fallback
- update sample xcodebuild destinations to include the pinned OS version

## Testing
- npx markdownlint docs/ci/ci-readiness.md *(fails: npm registry access blocked by 403 in sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958911e19588330a95df08aed34a598)