### PR TITLE
fix: use string literal in @Query predicate

### DIFF
--- a/ios/Offload/Features/Inbox/InboxView.swift
+++ b/ios/Offload/Features/Inbox/InboxView.swift
@@ -19,7 +19,7 @@ struct InboxView: View {
 
     @Query(
         filter: #Predicate<CaptureEntry> { entry in
-            entry.lifecycleState == LifecycleState.raw.rawValue
+            entry.lifecycleState == "raw"
         },
         sort: [SortDescriptor(\.createdAt, order: .reverse)]
     )


### PR DESCRIPTION
The @Query macro cannot evaluate LifecycleState.raw.rawValue in a key path context. Changed to use the string literal "raw" directly since lifecycleState is stored as a String in the model.

Fixes build error: "key path cannot refer to enum case 'raw'"