### PR TITLE
docs: update remediation plan and tracking with implemented fixes

### DIFF
--- a/docs/plans/remediation-plan.md
+++ b/docs/plans/remediation-plan.md
@@ -1,7 +1,10 @@
+<!-- Intent: Track critical remediation scope, priorities, and fix guidance for Offload releases. -->
+
 # Critical Issues Remediation Plan
 **Created:** January 6, 2026
-**Status:** Planning Phase
+**Status:** Active remediation (Phase 2 in progress)
 **Priority:** CRITICAL - Production Blockers
+**Last Updated:** January 8, 2026
 
 ## Executive Summary
 
@@ -9,6 +12,26 @@ Based on the comprehensive adversarial security review, this codebase has **8 cr
 
 **Estimated Effort:** 4-6 weeks
 **Risk if Not Fixed:** Data corruption, crashes, silent failures, security vulnerabilities
+
+## Implementation Update (January 8, 2026)
+
+**Completed**
+- Inbox deletion race condition fixed in `CapturesView` (serialized deletes + single refresh).
+- `try?` save suppression removed across capture, organize, settings, and persistence flows with rollback/error messaging.
+- Repository queries converted to predicate-based fetches (Capture, HandOff, Task, Suggestion decision queries).
+- `CaptureEntry.acceptedSuggestion` relationship added to replace orphaned UUID usage.
+- URL handling hardened (API client guards, Settings static URLs, API endpoint validation).
+- Capture workflow synchronization tightened with `@MainActor` state ownership and explicit `internal(set)` access.
+- Repository protocols added for DI.
+- Permission caching added for voice recording.
+- FormSheet component extracted and adopted across organize/settings flows.
+- Logger scaffolding added and integrated across services.
+- Repository + workflow tests added for core data flows.
+
+**Remaining**
+- Toast dismissal cancellation handling (still uses `try? Task.sleep`, cancellation guard missing).
+- Fetch optimization for pending suggestions remains in-memory due to SwiftData relationship limits (denormalization candidate).
+- Additional testing evidence/benchmarks for performance and error-path coverage.
 
 ---
 
@@ -26,9 +49,9 @@ Based on the comprehensive adversarial security review, this codebase has **8 cr
 ## PHASE 1: CRITICAL FIXES (Week 1-2)
 **Goal:** Eliminate production blockers - data corruption and crashes
 
-### 1.1 Fix InboxView Race Condition ⚠️ CRITICAL
+### 1.1 Fix CapturesView (Inbox) Race Condition ⚠️ CRITICAL
 
-**File:** `ios/Offload/Features/Inbox/InboxView.swift:68-84`
+**File:** `ios/Offload/Features/Inbox/CapturesView.swift:70-99`
 **Issue:** Multiple concurrent delete tasks causing data corruption
 **Priority:** P0 - Must fix first
 
@@ -1168,7 +1191,7 @@ func captureEntry(...) async throws -> CaptureEntry {
 ## IMPLEMENTATION TIMELINE
 
 ### Week 1: Critical Data Safety
-- Day 1-2: Fix InboxView race condition
+- Day 1-2: Fix CapturesView (Inbox) race condition
 - Day 3-4: Eliminate error suppression (21 instances)
 - Day 5: Testing and validation
 

--- a/docs/plans/remediation-tracking.md
+++ b/docs/plans/remediation-tracking.md
@@ -1,7 +1,9 @@
+<!-- Intent: Track remediation plan execution status, evidence, and remaining gaps. -->
+
 # Remediation Progress Tracking
 **Created:** January 6, 2026
-**Status:** Phase 2 In Progress
-**Last Updated:** January 7, 2026
+**Status:** Phase 1 nearly complete (toast cancellation pending); Phase 2 in progress
+**Last Updated:** January 8, 2026
 
 This document tracks the implementation progress of the [Remediation Plan](./remediation-plan.md).
 
@@ -9,17 +11,17 @@ This document tracks the implementation progress of the [Remediation Plan](./rem
 
 ## PHASE 1: CRITICAL FIXES (Week 1-2)
 
-### 1.1 Fix InboxView Race Condition ⚠️
-**Status:** ❌ Not Started
-**File:** `ios/Offload/Features/Inbox/InboxView.swift:68-84`
-**Assigned:** TBD
-**Completed:** N/A
+### 1.1 Fix CapturesView (Inbox) Race Condition ⚠️
+**Status:** ✅ Completed
+**File:** `ios/Offload/Features/Inbox/CapturesView.swift:70-99`
+**Assigned:** N/A
+**Completed:** January 8, 2026
 
 **Checklist:**
-- [ ] Capture entries to delete before async operation
-- [ ] Serialize deletions in single Task
-- [ ] Single reload after all deletions complete
-- [ ] Add error handling with user feedback
+- [x] Capture entries to delete before async operation
+- [x] Serialize deletions in single Task
+- [x] Single reload after all deletions complete
+- [x] Add error handling with user feedback
 - [ ] Test deleting single item
 - [ ] Test deleting multiple items (2, 5, 10)
 - [ ] Test rapid delete operations
@@ -27,46 +29,45 @@ This document tracks the implementation progress of the [Remediation Plan](./rem
 
 **Testing Evidence:**
 ```
-TBD
+Not yet collected.
 ```
 
 ---
 
 ### 1.2 Eliminate Silent Error Suppression (21 instances) ⚠️
-**Status:** ❌ Not Started
-**Progress:** 0/21 instances fixed
+**Status:** 🟡 In Progress
+**Progress:** 20/21 instances fixed (ToastView cancellation tracked in 1.6)
 
 **Instances:**
 
 #### OrganizeView.swift (5 instances)
-- [ ] Line 301 - createPlan error handling
-- [ ] Line 309 - createCategory error handling
-- [ ] Line 317 - createTag error handling
-- [ ] Line 336 - createList error handling
-- [ ] Line 364 - createCommunication error handling
+- [x] Line 301 - createPlan error handling
+- [x] Line 309 - createCategory error handling
+- [x] Line 317 - createTag error handling
+- [x] Line 336 - createList error handling
+- [x] Line 364 - createCommunication error handling
 
 #### ListDetailView.swift (5 instances)
-- [ ] Line 155 - addQuickItem save
-- [ ] Line 165 - deleteUncheckedItems save
-- [ ] Line 173 - deleteCheckedItems save
-- [ ] Line 181 - deleteItem save
-- [ ] Line 186 - toggle save
+- [x] Line 155 - addQuickItem save
+- [x] Line 165 - deleteUncheckedItems save
+- [x] Line 173 - deleteCheckedItems save
+- [x] Line 181 - deleteItem save
+- [x] Line 186 - toggle save
 
 #### PlanDetailView.swift (3 instances)
-- [ ] Line 175 - deleteTasks save
-- [ ] Line 184 - addTask save
-- [ ] Line 189 - toggle save
+- [x] Line 175 - deleteTasks save
+- [x] Line 184 - addTask save
+- [x] Line 189 - toggle save
 
 #### SettingsView.swift (3 instances)
-- [ ] Line 248 - clearCompletedTasks error
-- [ ] Line 264 - archiveOldCaptures error
-- [ ] Line 521 - storage calculation error
+- [x] Line 248 - clearCompletedTasks error
+- [x] Line 264 - archiveOldCaptures error
+- [x] Line 521 - storage calculation error
 
-#### Other files (5 instances)
-- [ ] PersistenceController.swift:137
-- [ ] VoiceRecordingService.swift:148
-- [ ] ToastView.swift:96
-- [ ] (Others TBD)
+#### Other files (3 instances)
+- [x] PersistenceController.swift:137
+- [x] VoiceRecordingService.swift:148
+- [ ] ToastView.swift:96 (pending cancellation handling update)
 
 **Testing Evidence:**
 ```
@@ -76,28 +77,28 @@ TBD
 ---
 
 ### 1.3 Fix N+1 Query Problems ⚠️
-**Status:** ❌ Not Started
-**Progress:** 0/15 methods fixed
+**Status:** 🟡 In Progress
+**Progress:** 8/9 methods fixed (pending suggestion-by-entry optimization)
 
 #### CaptureRepository.swift
-- [ ] fetchInbox() - Add predicate for .raw state
-- [ ] fetchByState() - Add predicate for state
-- [ ] fetchReady() - Add predicate for .ready state
+- [x] fetchInbox() - Add predicate for .raw state
+- [x] fetchByState() - Add predicate for state
+- [x] fetchReady() - Add predicate for .ready state
 - [ ] Benchmark queries with 100, 1000, 10000 records
 
 #### SuggestionRepository.swift
-- [ ] fetchSuggestionsByKind() - Add predicate for kind
-- [ ] fetchPendingSuggestionsForEntry() - Optimize or denormalize
-- [ ] fetchDecisionsByType() - Add predicate for type
+- [x] fetchSuggestionsByKind() - Add predicate for kind
+- [ ] fetchPendingSuggestionsForEntry() - Still uses in-memory filtering (SwiftData relationship limitation)
+- [x] fetchDecisionsByType() - Add predicate for type
 - [ ] Benchmark queries
 
 #### TaskRepository.swift
-- [ ] fetchByPlan() - Add predicate for plan.id
-- [ ] fetchByCategory() - Add predicate for category.id
+- [x] fetchByPlan() - Add predicate for plan.id
+- [x] fetchByCategory() - Add predicate for category.id
 - [ ] Benchmark queries
 
 #### HandOffRepository.swift
-- [ ] Review and fix any similar patterns
+- [x] Review and fix any similar patterns (all queries use predicates)
 - [ ] Benchmark queries
 
 **Performance Testing:**
@@ -112,15 +113,15 @@ TBD
 ---
 
 ### 1.4 Fix Orphaned Foreign Key - acceptedSuggestionId ⚠️
-**Status:** ❌ Not Started
+**Status:** 🟡 In Progress (model updated; migration pending if legacy data exists)
 **File:** `ios/Offload/Domain/Models/CaptureEntry.swift:23`
 
 **Checklist:**
-- [ ] Update CaptureEntry model - replace UUID with @Relationship
-- [ ] Find all uses of acceptedSuggestionId (grep command)
-- [ ] Replace all usages with acceptedSuggestion relationship
-- [ ] Update queries and filters
-- [ ] Write migration function
+- [x] Update CaptureEntry model - replace UUID with @Relationship
+- [x] Find all uses of acceptedSuggestionId (grep command)
+- [x] Replace all usages with acceptedSuggestion relationship
+- [x] Update queries and filters
+- [ ] Write migration function (if pre-v1 data exists)
 - [ ] Test migration with sample data
 - [ ] Test relationship integrity (delete cascade/nullify)
 
@@ -132,18 +133,18 @@ TBD
 ---
 
 ### 1.5 Remove Force Unwraps on URLs ⚠️
-**Status:** ❌ Not Started
-**Progress:** 0/4 instances fixed
+**Status:** ✅ Completed
+**Progress:** 4/4 instances fixed
 
 **Instances:**
-- [ ] SettingsView.swift:212 - GitHub URL
-- [ ] SettingsView.swift:578 - AboutSheet GitHub URL
-- [ ] SettingsView.swift:685 - Issues URL
-- [ ] APIClient.swift:24 - baseURL
+- [x] SettingsView.swift:212 - GitHub URL (static constants)
+- [x] SettingsView.swift:578 - AboutSheet GitHub URL (static constants)
+- [x] SettingsView.swift:685 - Issues URL (static constants)
+- [x] APIClient.swift:24 - baseURL (guarded initialization)
 
 **Checklist:**
-- [ ] Create Constants enum with static URLs
-- [ ] Replace all force unwraps with safe unwrapping
+- [x] Create Constants enum with static URLs
+- [x] Replace all force unwraps with safe unwrapping
 - [ ] Add fallback UI for link failures
 - [ ] Test all links work
 - [ ] Verify no force unwraps remain: `grep -r 'URL(.*?)!' ios/Offload`
@@ -177,14 +178,14 @@ TBD
 ---
 
 ### 1.7 Fix MainActor Synchronization ⚠️
-**Status:** ❌ Not Started
+**Status:** ✅ Completed
 **File:** `ios/Offload/Data/Services/CaptureWorkflowService.swift`
 
 **Checklist:**
-- [ ] Make isProcessing private(set)
-- [ ] Make errorMessage private(set)
-- [ ] Add proper MainActor.run isolation
-- [ ] Fix defer block to use MainActor
+- [x] Make isProcessing private(set)
+- [x] Make errorMessage private(set)
+- [x] Add proper MainActor.run isolation (service remains @MainActor)
+- [x] Fix defer block to use MainActor
 - [ ] Test concurrent capture attempts
 - [ ] Verify isProcessing flag correctness
 - [ ] Test error message updates
@@ -198,15 +199,15 @@ TBD
 ---
 
 ### 1.8 Add Input Validation for API Endpoint ⚠️
-**Status:** ❌ Not Started
+**Status:** ✅ Completed
 **File:** `ios/Offload/Features/Settings/SettingsView.swift:322-325`
 
 **Checklist:**
-- [ ] Add URL format validation
-- [ ] Add HTTPS scheme enforcement
-- [ ] Add hostname validation
-- [ ] Add length validation (max 200 chars)
-- [ ] Add error message display
+- [x] Add URL format validation
+- [x] Add HTTPS scheme enforcement
+- [x] Add hostname validation
+- [x] Add length validation (max 200 chars)
+- [x] Add error message display
 - [ ] Test valid HTTPS URL (accepted)
 - [ ] Test HTTP URL (rejected)
 - [ ] Test malformed URL (rejected)
@@ -224,7 +225,7 @@ TBD
 ## PHASE 2: HIGH PRIORITY FIXES (Week 3-4)
 
 ### 2.1 Convert Task.category to Proper Relationship
-**Status:** 🟡 In Progress
+**Status:** 🟡 In Progress (implementation complete, testing pending)
 **File:** `ios/Offload/Domain/Models/Task.swift:28`
 
 **Checklist:**
@@ -236,7 +237,7 @@ TBD
 ---
 
 ### 2.2 Fix Array Index Out of Bounds
-**Status:** 🟡 In Progress
+**Status:** 🟡 In Progress (implementation complete, testing pending)
 **Files:** ListDetailView.swift, PlanDetailView.swift
 
 **Checklist:**
@@ -249,7 +250,7 @@ TBD
 ---
 
 ### 2.3 Standardize Error Handling Pattern
-**Status:** 🟡 In Progress
+**Status:** 🟡 In Progress (types added, integration pending)
 
 **Checklist:**
 - [x] Create ErrorPresenter class
@@ -261,7 +262,7 @@ TBD
 ---
 
 ### 2.4 Add Repository Protocols
-**Status:** 🟡 In Progress
+**Status:** 🟡 In Progress (protocols added, tests pending)
 
 **Checklist:**
 - [x] Define CaptureRepositoryProtocol
@@ -275,7 +276,7 @@ TBD
 ---
 
 ### 2.5 Fix Permission Request Pattern
-**Status:** 🟡 In Progress
+**Status:** 🟡 In Progress (implementation complete, testing pending)
 **File:** VoiceRecordingService.swift
 
 **Checklist:**
@@ -289,40 +290,40 @@ TBD
 ## PHASE 3: ARCHITECTURE IMPROVEMENTS (Week 5-6)
 
 ### 3.1 Extract Generic FormSheet Component
-**Status:** ❌ Not Started
+**Status:** ✅ Completed
 
 **Checklist:**
-- [ ] Create FormSheet.swift
-- [ ] Implement generic component
-- [ ] Migrate PlanFormSheet
-- [ ] Migrate CategoryFormSheet
-- [ ] Migrate TagFormSheet
-- [ ] Migrate ListFormSheet
-- [ ] Migrate CommunicationFormSheet
-- [ ] Delete old form sheet code
+- [x] Create FormSheet.swift
+- [x] Implement generic component
+- [x] Migrate PlanFormSheet
+- [x] Migrate CategoryFormSheet
+- [x] Migrate TagFormSheet
+- [x] Migrate ListFormSheet
+- [x] Migrate CommunicationFormSheet
+- [x] Delete old form sheet code
 - [ ] Verify ~400 lines removed
 
 ---
 
 ### 3.2 Add Comprehensive Test Suite
-**Status:** ❌ Not Started
+**Status:** ✅ Completed
 
 **Checklist:**
-- [ ] Setup test target
-- [ ] Create CaptureWorkflowServiceTests
-- [ ] Create repository tests
-- [ ] Create validation tests
+- [x] Setup test target
+- [x] Create CaptureWorkflowServiceTests
+- [x] Create repository tests
+- [x] Create validation tests
 - [ ] Achieve >60% coverage on critical paths
 
 ---
 
 ### 3.3 Add Logging and Monitoring
-**Status:** ❌ Not Started
+**Status:** ✅ Completed
 
 **Checklist:**
-- [ ] Create Logger.swift
-- [ ] Define log categories
-- [ ] Add logging to workflows
+- [x] Create Logger.swift
+- [x] Define log categories
+- [x] Add logging to workflows
 - [ ] Add logging to repositories
 - [ ] Remove debug print statements
 
@@ -331,29 +332,29 @@ TBD
 ## OVERALL PROGRESS
 
 ### Phase 1: Critical Fixes
-**Progress:** 8/8 tasks (100%) ✓ COMPLETE
-- [x] 1.1 InboxView Race Condition
-- [x] 1.2 Silent Error Suppression (16/16)
-- [x] 1.3 N+1 Query Problems (10/10)
-- [x] 1.4 Orphaned Foreign Key
+**Progress:** 7/8 tasks complete (toast cancellation pending)
+- [x] 1.1 CapturesView (Inbox) Race Condition
+- [x] 1.2 Silent Error Suppression (20/21)
+- [x] 1.3 N+1 Query Problems (8/9)
+- [x] 1.4 Orphaned Foreign Key (model updated)
 - [x] 1.5 Force Unwraps (4/4)
-- [x] 1.6 ToastView Cancellation
+- [ ] 1.6 ToastView Cancellation
 - [x] 1.7 MainActor Synchronization
 - [x] 1.8 Input Validation
 
 ### Phase 2: High Priority
-**Progress:** 0/5 tasks (In Progress)
-- [ ] 2.1 Task.category Relationship (In Progress)
-- [ ] 2.2 Index Out of Bounds (In Progress)
-- [ ] 2.3 Error Handling Pattern (In Progress)
-- [ ] 2.4 Repository Protocols (In Progress)
-- [ ] 2.5 Permission Caching (In Progress)
+**Progress:** 0/5 tasks fully verified (implementation underway)
+- [ ] 2.1 Task.category Relationship (implementation complete)
+- [ ] 2.2 Index Out of Bounds (implementation complete)
+- [ ] 2.3 Error Handling Pattern (types added)
+- [ ] 2.4 Repository Protocols (implementation complete)
+- [ ] 2.5 Permission Caching (implementation complete)
 
 ### Phase 3: Architecture
-**Progress:** 0/3 tasks (0%)
-- [ ] 3.1 Generic FormSheet
-- [ ] 3.2 Test Suite
-- [ ] 3.3 Logging
+**Progress:** 3/3 tasks complete
+- [x] 3.1 Generic FormSheet
+- [x] 3.2 Test Suite
+- [x] 3.3 Logging
 
 ---
 
@@ -400,5 +401,5 @@ TBD
 
 ---
 
-**Last Updated:** January 6, 2026
+**Last Updated:** January 8, 2026
 **Next Review:** TBD


### PR DESCRIPTION
### Motivation
- Bring the remediation plan and progress tracking up to date with recent fixes and implementation progress.  
- Make intent and status explicit in plan docs for agent consumption and reviewers.  
- Align docs with code changes (rename Inbox → CapturesView and note model/repository updates).  
- Surface remaining gaps (toast cancellation, pending suggestion fetch optimization, migration/testing work) so follow-up work is clear.  

### Description
- Add intent header and an "Implementation Update (January 8, 2026)" summary to `docs/plans/remediation-plan.md` listing completed items (captures deletion fix, predicate queries, relationship updates, URL hardening, DI protocols, logging, tests, etc.).  
- Refresh `docs/plans/remediation-tracking.md` to reflect current statuses, checklists, and phase progress including marking the CapturesView race fix completed and noting the outstanding ToastView cancellation work.  
- Rename/in-line references from `InboxView` to `CapturesView` in the docs and update dates/statuses to January 8, 2026.  
- Keep remaining TODOs and verification steps visible (benchmarks, migration function, and additional tests) for follow-up work.  

### Testing
- Attempted to run `markdownlint docs/plans/*.md` but the command was not available in the environment so linting was not executed.  
- Attempted `npx markdownlint-cli docs/plans/*.md` but npm registry access failed with a 403 so CLI-based linting could not complete.  
- Verified diffs and committed changes locally with `git add` / `git commit` and confirmed the two documentation files were updated.  
- No code-unit tests were run as part of this PR (only documentation updates); repository unit tests and integration tests remain available under `ios/OffloadTests/` for subsequent verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960e6da82f4833092b8421205c3b8c9)