### PR TITLE
Align CI simulator OS pin

### DIFF
--- a/docs/sdlc/testing/baselines.md
+++ b/docs/sdlc/testing/baselines.md
@@ -9,7 +9,7 @@ Record wall-clock durations for key test commands to watch for regressions.
 ## Environment
 
 - Xcode: 16.2
-- Simulator: iPhone 16 Pro (iOS 18.3.1)
+- Simulator: iPhone 16 Pro (iOS 18.3)
 - Scheme: `offload`
 
 Command:

--- a/scripts/ci/readiness-env.sh
+++ b/scripts/ci/readiness-env.sh
@@ -7,4 +7,4 @@ set -euo pipefail
 export CI_MACOS_RUNNER="macos-14"
 export CI_XCODE_VERSION="16.2"
 export CI_SIM_DEVICE="iPhone 16"
-export CI_SIM_OS="18.3.1"
+export CI_SIM_OS="18.3"


### PR DESCRIPTION
### Motivation

- Prevent CI preflight failures caused by exact patch-level simulator OS mismatches when selecting simulators with `xcrun`/`xcodebuild`.
- Keep pinned CI environment values and documentation consistent to reduce confusion during CI troubleshooting.
- Reduce simulator selection flakiness across runners by using a broader runtime pin (`18.3`) instead of a patch-level pin (`18.3.1`).

### Description

- Update the pinned simulator OS in `scripts/ci/readiness-env.sh` by changing `CI_SIM_OS` from `18.3.1` to `18.3`.
- Sync the testing baseline documentation in `docs/sdlc/testing/baselines.md` to reference `iOS 18.3`.
- Change is scoped to CI readiness and documentation only and does not modify app source or tests.

### Testing

- Attempted to run `markdownlint docs/sdlc/testing/baselines.md`, but the `markdownlint` command was not available in the local environment so linting could not be validated here (failed).
- No other automated tests were run locally because this is a CI configuration/documentation change, and full validation will occur when the CI workflows (`.github/workflows/ios-build.yml` / `ios-tests.yml`) run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965b516325c8330a84fe727d283c76d)