### PR TITLE
docs: split v1 roadmap into individual feature plans

### DIFF
--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -107,6 +107,36 @@ sections:
       - id: plan-v1-roadmap
         title: Offload v1 Roadmap
         path: plans/plan-v1-roadmap.md
+      - id: plan-v1-testing-polish
+        title: "Plan: V1 Testing & Polish"
+        path: plans/plan-v1-testing-polish.md
+      - id: plan-v1-release-prep
+        title: "Plan: V1 Release Prep"
+        path: plans/plan-v1-release-prep.md
+      - id: plan-v1-tag-relationship-refactor
+        title: "Plan: Tag Relationship Refactor"
+        path: plans/plan-v1-tag-relationship-refactor.md
+      - id: plan-v1-view-decomposition
+        title: "Plan: View Decomposition"
+        path: plans/plan-v1-view-decomposition.md
+      - id: plan-v1-visual-timeline
+        title: "Plan: Visual Timeline"
+        path: plans/plan-v1-visual-timeline.md
+      - id: plan-v1-celebration-animations
+        title: "Plan: Celebration Animations"
+        path: plans/plan-v1-celebration-animations.md
+      - id: plan-v1-advanced-accessibility
+        title: "Plan: Advanced Accessibility Features"
+        path: plans/plan-v1-advanced-accessibility.md
+      - id: plan-v1-ai-organization-flows
+        title: "Plan: AI Organization Flows & Review Screen"
+        path: plans/plan-v1-ai-organization-flows.md
+      - id: plan-v1-ai-pricing-limits
+        title: "Plan: AI Pricing & Limits"
+        path: plans/plan-v1-ai-pricing-limits.md
+      - id: plan-v1-backend-api-privacy
+        title: "Plan: Backend API + Privacy Constraints"
+        path: plans/plan-v1-backend-api-privacy.md
       - id: plan-archived-error-handling-improvements
         title: Error Handling Improvements Plan
         path: plans/_archived/plan-archived-error-handling-improvements.md

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -58,6 +58,19 @@ draft → active → completed | archived
 ### Active
 
 - [Offload v1 Roadmap](./plan-v1-roadmap.md) - Single source of truth for v1
+- [Plan: V1 Testing & Polish](./plan-v1-testing-polish.md)
+- [Plan: V1 Release Prep](./plan-v1-release-prep.md)
+
+### Draft (Pre-v1 Candidates)
+
+- [Plan: Tag Relationship Refactor](./plan-v1-tag-relationship-refactor.md)
+- [Plan: View Decomposition](./plan-v1-view-decomposition.md)
+- [Plan: Visual Timeline](./plan-v1-visual-timeline.md)
+- [Plan: Celebration Animations](./plan-v1-celebration-animations.md)
+- [Plan: Advanced Accessibility Features](./plan-v1-advanced-accessibility.md)
+- [Plan: AI Organization Flows & Review Screen](./plan-v1-ai-organization-flows.md)
+- [Plan: AI Pricing & Limits](./plan-v1-ai-pricing-limits.md)
+- [Plan: Backend API + Privacy Constraints](./plan-v1-backend-api-privacy.md)
 
 ### Archived
 

--- a/docs/plans/plan-v1-advanced-accessibility.md
+++ b/docs/plans/plan-v1-advanced-accessibility.md
@@ -1,0 +1,68 @@
+---
+id: plan-v1-advanced-accessibility
+type: plan
+status: draft
+owners:
+  - Offload
+applies_to:
+  - pre-v1-scope
+last_updated: 2026-01-20
+related:
+  - plan-v1-roadmap
+structure_notes:
+  - "Section order: Overview; Goals; Phases; Dependencies; Risks; Progress."
+---
+
+# Plan: Advanced Accessibility Features (Pre-v1 Candidate)
+
+## Overview
+
+Execution plan for advanced accessibility features listed as additional pre-v1
+scope in the v1 roadmap. Work should begin only after scope is confirmed via
+PRD/ADR updates.
+
+## Goals
+
+- Deliver accessibility enhancements beyond baseline v1 requirements.
+- Ensure features are validated with assistive technologies.
+
+## Phases
+
+### Phase 1: Scope Confirmation
+
+**Status:** Not Started
+
+- [ ] Confirm scope approval in PRD/ADR updates.
+- [ ] Define the advanced accessibility feature set.
+
+### Phase 2: Implementation Planning
+
+**Status:** Not Started
+
+- [ ] Map features to affected views and components.
+- [ ] Identify testing requirements and tooling.
+
+### Phase 3: Implementation & Validation
+
+**Status:** Not Started
+
+- [ ] Implement enhancements.
+- [ ] Validate with VoiceOver, Switch Control, and dynamic type.
+
+## Dependencies
+
+- Approved PRD/ADR updates for advanced accessibility scope.
+- Accessibility testing guidance and tooling.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Feature creep delays v1 | M | Keep work gated until scope is approved. |
+| Accessibility regressions | M | Run regression testing after each change. |
+
+## Progress
+
+| Date | Update |
+| --- | --- |
+| 2026-01-20 | Plan created from v1 roadmap split. |

--- a/docs/plans/plan-v1-ai-organization-flows.md
+++ b/docs/plans/plan-v1-ai-organization-flows.md
@@ -1,0 +1,68 @@
+---
+id: plan-v1-ai-organization-flows
+type: plan
+status: draft
+owners:
+  - Offload
+applies_to:
+  - pre-v1-scope
+last_updated: 2026-01-20
+related:
+  - plan-v1-roadmap
+structure_notes:
+  - "Section order: Overview; Goals; Phases; Dependencies; Risks; Progress."
+---
+
+# Plan: AI Organization Flows & Review Screen (Pre-v1 Candidate)
+
+## Overview
+
+Execution plan for the optional AI organization flows and review screen listed
+as additional pre-v1 scope in the v1 roadmap. Work should begin only after
+scope is confirmed via PRD/ADR updates.
+
+## Goals
+
+- Define the workflow for AI-assisted organization.
+- Ensure review screens align with approved product requirements.
+
+## Phases
+
+### Phase 1: Scope Confirmation
+
+**Status:** Not Started
+
+- [ ] Confirm scope approval in PRD/ADR updates.
+- [ ] Identify target user flows and review surfaces.
+
+### Phase 2: Workflow Definition
+
+**Status:** Not Started
+
+- [ ] Document flow steps and handoffs.
+- [ ] Align with privacy and backend constraints.
+
+### Phase 3: Implementation & Validation
+
+**Status:** Not Started
+
+- [ ] Build UI flow scaffolding.
+- [ ] Validate with manual testing and UX review.
+
+## Dependencies
+
+- Approved PRD/ADR updates for AI scope.
+- Backend API and privacy constraints plan.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| AI scope expands beyond v1 | H | Keep work gated until scope is approved. |
+| Privacy constraints unclear | H | Align with backend/privacy plan before build. |
+
+## Progress
+
+| Date | Update |
+| --- | --- |
+| 2026-01-20 | Plan created from v1 roadmap split. |

--- a/docs/plans/plan-v1-ai-pricing-limits.md
+++ b/docs/plans/plan-v1-ai-pricing-limits.md
@@ -1,0 +1,69 @@
+---
+id: plan-v1-ai-pricing-limits
+type: plan
+status: draft
+owners:
+  - Offload
+applies_to:
+  - pre-v1-scope
+last_updated: 2026-01-20
+related:
+  - plan-v1-roadmap
+  - plan-v1-ai-organization-flows
+structure_notes:
+  - "Section order: Overview; Goals; Phases; Dependencies; Risks; Progress."
+---
+
+# Plan: AI Pricing & Limits (Pre-v1 Candidate)
+
+## Overview
+
+Execution plan for AI pricing and limits (free/paid tiers, server-side
+enforcement) listed as additional pre-v1 scope in the v1 roadmap. Work should
+begin only after scope is confirmed via PRD/ADR updates.
+
+## Goals
+
+- Define pricing and usage limits for AI features.
+- Ensure enforcement aligns with backend capabilities and privacy constraints.
+
+## Phases
+
+### Phase 1: Scope Confirmation
+
+**Status:** Not Started
+
+- [ ] Confirm scope approval in PRD/ADR updates.
+- [ ] Identify pricing tiers and enforcement requirements.
+
+### Phase 2: Policy Definition
+
+**Status:** Not Started
+
+- [ ] Document usage limits and tier behaviors.
+- [ ] Align with billing and backend enforcement design.
+
+### Phase 3: Implementation & Validation
+
+**Status:** Not Started
+
+- [ ] Implement client-side limit handling.
+- [ ] Validate enforcement with backend integration.
+
+## Dependencies
+
+- Approved PRD/ADR updates for AI scope.
+- Backend API + privacy constraints plan.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Pricing changes introduce scope creep | M | Keep decisions in PRD/ADR updates. |
+| Enforcement gaps | H | Validate backend enforcement early. |
+
+## Progress
+
+| Date | Update |
+| --- | --- |
+| 2026-01-20 | Plan created from v1 roadmap split. |

--- a/docs/plans/plan-v1-backend-api-privacy.md
+++ b/docs/plans/plan-v1-backend-api-privacy.md
@@ -1,0 +1,68 @@
+---
+id: plan-v1-backend-api-privacy
+type: plan
+status: draft
+owners:
+  - Offload
+applies_to:
+  - pre-v1-scope
+last_updated: 2026-01-20
+related:
+  - plan-v1-roadmap
+structure_notes:
+  - "Section order: Overview; Goals; Phases; Dependencies; Risks; Progress."
+---
+
+# Plan: Backend API + Privacy Constraints (Pre-v1 Candidate)
+
+## Overview
+
+Execution plan for backend API and privacy constraints listed as additional
+pre-v1 scope in the v1 roadmap. Work should begin only after scope is confirmed
+via PRD/ADR updates.
+
+## Goals
+
+- Define backend API integration needs for AI features.
+- Establish privacy constraints and compliance requirements.
+
+## Phases
+
+### Phase 1: Scope Confirmation
+
+**Status:** Not Started
+
+- [ ] Confirm scope approval in PRD/ADR updates.
+- [ ] Identify data flows that require backend support.
+
+### Phase 2: API & Privacy Definition
+
+**Status:** Not Started
+
+- [ ] Document API endpoints and data handling expectations.
+- [ ] Define privacy constraints and data retention policies.
+
+### Phase 3: Implementation & Validation
+
+**Status:** Not Started
+
+- [ ] Implement API integration scaffolding.
+- [ ] Validate data handling against privacy requirements.
+
+## Dependencies
+
+- Approved PRD/ADR updates for AI scope.
+- Security and compliance review readiness.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Privacy constraints change late | H | Lock requirements before implementation. |
+| Backend API delays | H | Sequence implementation after API readiness. |
+
+## Progress
+
+| Date | Update |
+| --- | --- |
+| 2026-01-20 | Plan created from v1 roadmap split. |

--- a/docs/plans/plan-v1-celebration-animations.md
+++ b/docs/plans/plan-v1-celebration-animations.md
@@ -1,0 +1,68 @@
+---
+id: plan-v1-celebration-animations
+type: plan
+status: draft
+owners:
+  - Offload
+applies_to:
+  - pre-v1-scope
+last_updated: 2026-01-20
+related:
+  - plan-v1-roadmap
+structure_notes:
+  - "Section order: Overview; Goals; Phases; Dependencies; Risks; Progress."
+---
+
+# Plan: Celebration Animations (Pre-v1 Candidate)
+
+## Overview
+
+Execution plan for the optional celebration animations feature listed as
+additional pre-v1 scope in the v1 roadmap. Work should begin only after scope
+is confirmed via PRD/ADR updates.
+
+## Goals
+
+- Add positive feedback moments without overwhelming the core UX.
+- Keep animations consistent with the existing design system.
+
+## Phases
+
+### Phase 1: Scope Confirmation
+
+**Status:** Not Started
+
+- [ ] Confirm scope approval in PRD/ADR updates.
+- [ ] Identify key moments that trigger celebrations.
+
+### Phase 2: Design Alignment
+
+**Status:** Not Started
+
+- [ ] Review design system guidance for motion.
+- [ ] Define animation patterns and durations.
+
+### Phase 3: Implementation & Validation
+
+**Status:** Not Started
+
+- [ ] Implement animations in target views.
+- [ ] Validate performance and accessibility impact.
+
+## Dependencies
+
+- Approved PRD/ADR updates.
+- Motion guidance in the design system.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Animations distract from core flow | M | Keep animations subtle and optional. |
+| Performance impacts on older devices | M | Profile animations during testing. |
+
+## Progress
+
+| Date | Update |
+| --- | --- |
+| 2026-01-20 | Plan created from v1 roadmap split. |

--- a/docs/plans/plan-v1-release-prep.md
+++ b/docs/plans/plan-v1-release-prep.md
@@ -1,0 +1,71 @@
+---
+id: plan-v1-release-prep
+type: plan
+status: active
+owners:
+  - Offload
+applies_to:
+  - v1-release
+last_updated: 2026-01-20
+related:
+  - plan-v1-roadmap
+  - plan-v1-testing-polish
+structure_notes:
+  - "Section order: Overview; Goals; Phases; Dependencies; Risks; Progress."
+---
+
+# Plan: V1 Release Prep
+
+## Overview
+
+Execution plan for release preparation tasks required after testing and polish
+are complete. This plan covers documentation updates, release notes, App Store
+metadata, and TestFlight distribution.
+
+## Goals
+
+- Prepare documentation and release notes for v1 launch.
+- Finalize App Store metadata and assets.
+- Distribute builds via TestFlight for final validation.
+
+## Phases
+
+### Phase 1: Documentation & Release Notes
+
+**Status:** Not Started
+
+- [ ] Update documentation tied to v1 scope and readiness.
+- [ ] Draft v1 release notes.
+
+### Phase 2: App Store Metadata
+
+**Status:** Not Started
+
+- [ ] Validate App Store metadata fields.
+- [ ] Confirm screenshots and descriptions are current.
+
+### Phase 3: TestFlight Distribution
+
+**Status:** Not Started
+
+- [ ] Prepare TestFlight build.
+- [ ] Coordinate tester distribution and feedback window.
+
+## Dependencies
+
+- Completion of v1 testing and polish plan.
+- Updated product requirements and design assets, if needed.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Documentation gaps | M | Review PRDs and ADRs before updates. |
+| App Store assets outdated | M | Audit assets early in Phase 2. |
+| TestFlight feedback delays | L | Schedule buffer before final submission. |
+
+## Progress
+
+| Date | Update |
+| --- | --- |
+| 2026-01-20 | Plan created from v1 roadmap split. |

--- a/docs/plans/plan-v1-roadmap.md
+++ b/docs/plans/plan-v1-roadmap.md
@@ -7,7 +7,17 @@ owners:
 applies_to:
   - v1-release
 last_updated: 2026-01-20
-related: []
+related:
+  - plan-v1-testing-polish
+  - plan-v1-release-prep
+  - plan-v1-tag-relationship-refactor
+  - plan-v1-view-decomposition
+  - plan-v1-visual-timeline
+  - plan-v1-celebration-animations
+  - plan-v1-advanced-accessibility
+  - plan-v1-ai-organization-flows
+  - plan-v1-ai-pricing-limits
+  - plan-v1-backend-api-privacy
 priority: critical
 structure_notes:
   - "Single source of truth for v1 release planning"
@@ -85,36 +95,21 @@ handling work is effectively complete.
 
 ## Remaining Work for v1
 
-### Week 1: Testing & Polish
+### Active execution plans
 
-- Manual testing of all features
-- Performance benchmarks
-- Bug fixes from testing
-- Accessibility review
-- Verify voice recording (permissions, start/stop, on-device transcription)
-- Verify offline capture and persistence
-- Validate Capture List actions (complete, star, delete) against PRD
-- Confirm UX tone requirements in core capture/organize flows
+- [Plan: V1 Testing & Polish](./plan-v1-testing-polish.md)
+- [Plan: V1 Release Prep](./plan-v1-release-prep.md)
 
-### Week 2: Release Prep
+### Pre-v1 candidate scope (requires PRD/ADR confirmation)
 
-- Documentation updates
-- Release notes
-- App Store metadata
-- TestFlight distribution
-
-### Additional pre-v1 scope
-
-- Tag relationship refactor (migration risk)
-- View decomposition (CollectionDetailView at 778 lines)
-- Visual timeline (ADHD feature)
-- Celebration animations
-- Advanced accessibility features
-- AI organization flows and review screen
-- AI pricing & limits (free/paid tiers, server-side enforcement)
-- Backend API + privacy constraints for AI integration
-
-**Total:** TBD based on additional pre-v1 scope
+- [Plan: Tag Relationship Refactor](./plan-v1-tag-relationship-refactor.md)
+- [Plan: View Decomposition](./plan-v1-view-decomposition.md)
+- [Plan: Visual Timeline](./plan-v1-visual-timeline.md)
+- [Plan: Celebration Animations](./plan-v1-celebration-animations.md)
+- [Plan: Advanced Accessibility Features](./plan-v1-advanced-accessibility.md)
+- [Plan: AI Organization Flows & Review Screen](./plan-v1-ai-organization-flows.md)
+- [Plan: AI Pricing & Limits](./plan-v1-ai-pricing-limits.md)
+- [Plan: Backend API + Privacy Constraints](./plan-v1-backend-api-privacy.md)
 
 ## File Sizes Reference
 

--- a/docs/plans/plan-v1-tag-relationship-refactor.md
+++ b/docs/plans/plan-v1-tag-relationship-refactor.md
@@ -1,0 +1,68 @@
+---
+id: plan-v1-tag-relationship-refactor
+type: plan
+status: draft
+owners:
+  - Offload
+applies_to:
+  - pre-v1-scope
+last_updated: 2026-01-20
+related:
+  - plan-v1-roadmap
+structure_notes:
+  - "Section order: Overview; Goals; Phases; Dependencies; Risks; Progress."
+---
+
+# Plan: Tag Relationship Refactor (Pre-v1 Candidate)
+
+## Overview
+
+Execution plan for the optional tag relationship refactor listed as additional
+pre-v1 scope in the v1 roadmap. Work should begin only after scope is confirmed
+via PRD/ADR updates.
+
+## Goals
+
+- Reduce migration risk tied to tag relationships.
+- Maintain data integrity during any schema transitions.
+
+## Phases
+
+### Phase 1: Scope Confirmation
+
+**Status:** Not Started
+
+- [ ] Confirm scope approval in PRD/ADR updates.
+- [ ] Identify impacted SwiftData models and repositories.
+
+### Phase 2: Migration Planning
+
+**Status:** Not Started
+
+- [ ] Define migration steps and rollback plan.
+- [ ] Document required data validation checks.
+
+### Phase 3: Implementation & Validation
+
+**Status:** Not Started
+
+- [ ] Execute refactor and run migration checks.
+- [ ] Validate tag queries and relationships.
+
+## Dependencies
+
+- Approved PRD/ADR updates for pre-v1 scope.
+- SwiftData migration guidance and test coverage.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Migration causes data loss | H | Validate backups and run staged migration tests. |
+| Scope shifts delay v1 | M | Keep work gated behind scope confirmation. |
+
+## Progress
+
+| Date | Update |
+| --- | --- |
+| 2026-01-20 | Plan created from v1 roadmap split. |

--- a/docs/plans/plan-v1-testing-polish.md
+++ b/docs/plans/plan-v1-testing-polish.md
@@ -1,0 +1,84 @@
+---
+id: plan-v1-testing-polish
+type: plan
+status: active
+owners:
+  - Offload
+applies_to:
+  - v1-release
+last_updated: 2026-01-20
+related:
+  - plan-v1-roadmap
+structure_notes:
+  - "Section order: Overview; Goals; Phases; Dependencies; Risks; Progress."
+---
+
+# Plan: V1 Testing & Polish
+
+## Overview
+
+Execution plan for the final v1 testing and polish work identified in the v1
+roadmap. This plan sequences manual testing, performance validation, bug fixes,
+and accessibility review before release prep begins.
+
+## Goals
+
+- Validate core capture, organize, and collection workflows against approved
+  scope.
+- Resolve defects discovered during manual testing.
+- Confirm accessibility, permissions, and offline behavior are stable for v1.
+
+## Phases
+
+### Phase 1: Manual Feature Verification
+
+**Status:** Not Started
+
+- [ ] Run the v1 manual testing checklist end-to-end.
+- [ ] Verify capture list actions (complete, star, delete) match PRD intent.
+- [ ] Confirm voice recording (permissions, start/stop, transcription).
+- [ ] Validate offline capture and persistence.
+- [ ] Review UX tone requirements in core capture/organize flows.
+
+### Phase 2: Performance & Reliability
+
+**Status:** Not Started
+
+- [ ] Capture baseline launch and navigation timing notes.
+- [ ] Run pagination flows under large data sets.
+- [ ] Document any regressions or slow paths to address in Phase 3.
+
+### Phase 3: Bug Fixes & Polish
+
+**Status:** Not Started
+
+- [ ] Triage issues found in Phases 1-2.
+- [ ] Implement fixes and retest affected flows.
+- [ ] Confirm no regressions in core navigation.
+
+### Phase 4: Accessibility Review
+
+**Status:** Not Started
+
+- [ ] Review VoiceOver support for core views.
+- [ ] Validate contrast, tap targets, and focus order.
+- [ ] Log any v1 blockers and confirm resolution.
+
+## Dependencies
+
+- V1 manual testing artifacts in `docs/design/testing/`.
+- Stable build of the iOS app for QA execution.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Late defects extend timeline | M | Prioritize blockers and defer non-critical polish. |
+| Accessibility gaps found late | M | Run accessibility checks early in Phase 4. |
+| Performance regressions | M | Track baseline results and retest after fixes. |
+
+## Progress
+
+| Date | Update |
+| --- | --- |
+| 2026-01-20 | Plan created from v1 roadmap split. |

--- a/docs/plans/plan-v1-view-decomposition.md
+++ b/docs/plans/plan-v1-view-decomposition.md
@@ -1,0 +1,68 @@
+---
+id: plan-v1-view-decomposition
+type: plan
+status: draft
+owners:
+  - Offload
+applies_to:
+  - pre-v1-scope
+last_updated: 2026-01-20
+related:
+  - plan-v1-roadmap
+structure_notes:
+  - "Section order: Overview; Goals; Phases; Dependencies; Risks; Progress."
+---
+
+# Plan: View Decomposition (Pre-v1 Candidate)
+
+## Overview
+
+Execution plan for decomposing large SwiftUI views listed as optional pre-v1
+scope in the v1 roadmap. Work should begin only after scope is confirmed via
+PRD/ADR updates.
+
+## Goals
+
+- Reduce risk by breaking large views into focused components.
+- Improve readability and maintainability before release.
+
+## Phases
+
+### Phase 1: Scope Confirmation
+
+**Status:** Not Started
+
+- [ ] Confirm scope approval in PRD/ADR updates.
+- [ ] Prioritize views based on size and complexity.
+
+### Phase 2: Decomposition Plan
+
+**Status:** Not Started
+
+- [ ] Identify subviews and shared components.
+- [ ] Document sequencing and ownership boundaries.
+
+### Phase 3: Refactor & Verification
+
+**Status:** Not Started
+
+- [ ] Implement view splits.
+- [ ] Verify navigation, bindings, and state flows.
+
+## Dependencies
+
+- Scope confirmation for pre-v1 work.
+- Updated design system guidance for shared components.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Refactor introduces regressions | M | Incremental refactors with focused QA. |
+| Schedule impact | M | Prioritize only the largest views if time is limited. |
+
+## Progress
+
+| Date | Update |
+| --- | --- |
+| 2026-01-20 | Plan created from v1 roadmap split. |

--- a/docs/plans/plan-v1-visual-timeline.md
+++ b/docs/plans/plan-v1-visual-timeline.md
@@ -1,0 +1,68 @@
+---
+id: plan-v1-visual-timeline
+type: plan
+status: draft
+owners:
+  - Offload
+applies_to:
+  - pre-v1-scope
+last_updated: 2026-01-20
+related:
+  - plan-v1-roadmap
+structure_notes:
+  - "Section order: Overview; Goals; Phases; Dependencies; Risks; Progress."
+---
+
+# Plan: Visual Timeline (Pre-v1 Candidate)
+
+## Overview
+
+Execution plan for the optional visual timeline feature listed as additional
+pre-v1 scope in the v1 roadmap. Work should begin only after scope is confirmed
+via PRD/ADR updates.
+
+## Goals
+
+- Provide a clear, visual representation of progress for ADHD-focused flows.
+- Integrate the timeline without disrupting core capture/organize workflows.
+
+## Phases
+
+### Phase 1: Scope Confirmation
+
+**Status:** Not Started
+
+- [ ] Confirm scope approval in PRD/ADR updates.
+- [ ] Identify target views for timeline placement.
+
+### Phase 2: UX + Design Alignment
+
+**Status:** Not Started
+
+- [ ] Review UX guidance and design artifacts.
+- [ ] Document timeline states and transitions to implement.
+
+### Phase 3: Implementation & Validation
+
+**Status:** Not Started
+
+- [ ] Build the timeline components.
+- [ ] Validate with manual testing and accessibility checks.
+
+## Dependencies
+
+- Approved PRD/ADR updates.
+- Design assets and UX guidance.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Scope adds complexity to v1 timeline | M | Keep work gated until scope approval. |
+| Visuals conflict with design system | M | Align with design system before build. |
+
+## Progress
+
+| Date | Update |
+| --- | --- |
+| 2026-01-20 | Plan created from v1 roadmap split. |


### PR DESCRIPTION
### Motivation

- Split the monolithic v1 roadmap into focused execution plans to make testing, release preparation, and optional pre-v1 candidate work easier to track and execute.  
- Surface pre-v1 candidate scope as separate draft plans so each effort can be reviewed and gated by PRD/ADR confirmation.  
- Keep documentation navigation and the plans index in sync so the new plan files are discoverable; these updates should be applied from a feature branch (for example `docs/split-v1-plans`).

### Description

- Added individual plan documents under `docs/plans/` for testing/polish and release prep plus draft pre-v1 candidates (`plan-v1-testing-polish.md`, `plan-v1-release-prep.md`, `plan-v1-tag-relationship-refactor.md`, `plan-v1-view-decomposition.md`, `plan-v1-visual-timeline.md`, `plan-v1-celebration-animations.md`, `plan-v1-advanced-accessibility.md`, `plan-v1-ai-organization-flows.md`, `plan-v1-ai-pricing-limits.md`, `plan-v1-backend-api-privacy.md`).  
- Updated `docs/plans/plan-v1-roadmap.md` to reference the new plan documents and reorganized the "Remaining Work for v1" section into active execution plans and pre-v1 candidate scope.  
- Updated `docs/plans/README.md` to list the new active plans and draft pre-v1 candidates.  
- Updated `docs/index.yaml` to add navigation entries for all new plan files so they appear in the documentation index.

### Testing

- Attempted to run the documentation linter with `markdownlint docs/**/*.md`, but the command failed in this environment with `command not found`.  
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697164412ed88330a62940cb3446febc)