### PR TITLE
docs: add 6 PRDs for cognitive support features

### DIFF
--- a/docs/prds/prd-0007-smart-task-breakdown.md
+++ b/docs/prds/prd-0007-smart-task-breakdown.md
@@ -1,0 +1,353 @@
+---
+id: prd-0007-smart-task-breakdown
+type: product-requirements
+status: draft
+owners:
+  - Offload
+applies_to:
+  - product
+last_updated: 2026-01-24
+related:
+  - adr-0003-adhd-focused-ux-ui-guardrails
+  - prd-0001-product-requirements
+structure_notes:
+  - "Section order: 1. Product overview; 2. Problem statement; 3. Product goals; 4. Non-goals (explicit); 5. Target audience; 6. Success metrics; 7. Core user flows; 8. Functional requirements; 9. Pricing & limits; 10. AI & backend requirements; 11. Data model; 12. UX & tone requirements; 13. Risks & mitigations; 14. Implementation tracking; 15. Open decisions; 16. Revision history."
+---
+
+# Offload — Smart Task Breakdown PRD
+
+**Version:** 1.0
+**Date:** 2026-01-24
+**Status:** Draft
+**Owner:** Offload
+
+**Related ADRs:**
+
+- [adr-0003: ADHD-Focused UX/UI Guardrails](../adrs/adr-0003-adhd-focused-ux-ui-guardrails.md)
+- [prd-0001: V1 Product Requirements](prd-0001-product-requirements.md)
+
+---
+
+## 1. Product overview
+
+Smart Task Breakdown transforms overwhelming tasks into manageable step-by-step
+plans using AI. Unlike traditional task managers that require users to manually
+decompose tasks, this feature intelligently suggests subtasks with adjustable
+granularity. Users can save breakdown templates for recurring task types,
+creating a personalized library of task patterns that work for their brain.
+
+**Key differentiator:** Breakdown templates persist and can be reused, edited,
+and refined over time. The AI learns from user's preferred breakdown patterns,
+unlike standalone task decomposition tools.
+
+---
+
+## 2. Problem statement
+
+People often know what needs to be done but feel paralyzed by not knowing where
+to start. Breaking down tasks into smaller steps is cognitively expensive and
+feels like additional work before the "real" work can begin.
+
+**Core user pain:**
+> "I know I need to clean the apartment, but I can't figure out where to start.
+> By the time I've thought through all the steps, I'm already exhausted."
+
+**Gap in existing productivity tools:**
+
+- Task breakdown tools don't save custom edits
+- Cannot reuse breakdown patterns for similar tasks
+- No learning from user preferences over time
+- Breakdowns often don't persist after task completion
+
+---
+
+## 3. Product goals
+
+- Reduce the cognitive load of task decomposition
+- Enable users to save and reuse breakdown templates for recurring tasks
+- Provide adjustable granularity to match current executive function capacity
+- Maintain user control: AI suggests, never auto-creates without approval
+- Support both one-off breakdowns and template creation
+- Work completely offline with on-device AI processing
+
+---
+
+## 4. Non-goals (explicit)
+
+- No automatic task scheduling or calendar integration
+- No time-based reminders or notifications
+- No collaboration or shared task templates
+- No rigid task hierarchies (maintain flexible structure)
+- No forced completion of all subtasks to complete parent task
+- No gamification, streaks, or completion pressure
+
+---
+
+## 5. Target audience
+
+- Users who struggle with task initiation
+- People who know what needs doing but can't break it down into steps
+- Those who have recurring tasks (cleaning routines, packing, project workflows)
+- Users who want AI assistance without giving up control
+- Existing Offload users who capture tasks but struggle to organize them
+
+---
+
+## 6. Success metrics (30-day post-launch)
+
+| Metric ID | Metric | Baseline | Target | Measurement |
+| --- | --- | --- | --- | --- |
+| M-700 | % of items that use breakdown | TBD | ≥20% | Analytics events |
+| M-701 | % of breakdowns that are saved as templates | TBD | ≥30% | Template creation events |
+| M-702 | Template reuse rate | TBD | ≥15% | Template application events |
+| M-703 | User satisfaction with breakdown quality | TBD | ≥4.2/5 | In-app survey |
+| M-704 | Average time from capture to first subtask completion | TBD | -30% | Task timing analysis |
+| M-705 | % of users who customize suggested breakdowns | TBD | ≥40% | Edit events |
+
+---
+
+## 7. Core user flows
+
+### 7.1 One-off task breakdown
+
+1. User has a captured item: "Clean the apartment"
+2. User taps breakdown action (from context menu or detail view)
+3. User adjusts granularity slider (1-5 detail level)
+4. AI generates breakdown as a structured Collection with subtasks
+5. User reviews, edits, approves breakdown
+6. Item is converted to a Plan with hierarchical subtasks
+7. User can check off subtasks as they complete them
+
+### 7.2 Save breakdown as template
+
+1. User completes flow 7.1 and reviews generated breakdown
+2. User taps "Save as template"
+3. User names template (e.g., "Deep clean routine")
+4. Template is saved with pattern matching keywords
+5. Future similar tasks suggest: "Apply 'Deep clean routine' template?"
+
+### 7.3 Apply existing template
+
+1. User captures: "Clean before guests arrive"
+2. AI recognizes similarity to saved template
+3. Suggestion appears: "Apply 'Deep clean routine'?" with preview
+4. User taps apply, reviews generated breakdown (customized to context)
+5. User edits if needed and approves
+
+### 7.4 Manage templates
+
+1. User navigates to Settings → Task Templates
+2. User sees list of saved templates with usage count
+3. User can view, edit, delete, or rename templates
+4. User can manually apply template to any captured item
+
+---
+
+## 8. Functional requirements
+
+| Req ID | Requirement | Priority | User Story |
+| --- | --- | --- | --- |
+| FR-700 | Provide breakdown action for captured items | Must | US-700 |
+| FR-701 | AI generates subtask breakdown with adjustable granularity | Must | US-701 |
+| FR-702 | Granularity control (1-5 levels) affects number and detail of subtasks | Must | US-702 |
+| FR-703 | User can edit suggested breakdown before accepting | Must | US-703 |
+| FR-704 | Breakdown creates structured Collection with hierarchical CollectionItems | Must | US-704 |
+| FR-705 | Support saving breakdown as reusable template | Must | US-705 |
+| FR-706 | Templates include name and pattern matching keywords | Must | US-706 |
+| FR-707 | AI suggests relevant templates for new captures | Should | US-707 |
+| FR-708 | User can manually apply template to any item | Should | US-708 |
+| FR-709 | Template management UI (view, edit, delete, rename) | Should | US-709 |
+| FR-710 | Templates show usage count and last used date | Could | US-710 |
+| FR-711 | User can share individual subtasks with others | Won't | - |
+| FR-712 | Templates sync across devices | Won't | - |
+
+---
+
+## 9. Pricing & limits (hybrid model)
+
+### Free tier
+
+- 10 AI breakdowns per month
+- Unlimited template applications (using existing templates doesn't count toward limit)
+- Unlimited manual subtask creation
+- Up to 5 saved templates
+
+### Paid tier
+
+- Unlimited AI breakdowns
+- Unlimited templates
+- Priority processing for on-device AI
+- Early access to breakdown refinement features
+
+**Rationale:** Template reuse encourages users to build a personal system
+without hitting AI limits, while power users can upgrade for unlimited generation.
+
+---
+
+## 10. AI & backend requirements
+
+### On-device AI (Phase 1 - Offline)
+
+- Use on-device language model for breakdown generation
+- Model must understand task decomposition patterns
+- Context window sufficient for ~500 words of task description
+- Response time <3 seconds for breakdown generation
+- Fallback gracefully if AI unavailable
+
+### Backend AI (Phase 2+ - Optional)
+
+- Cloud-based LLM for higher quality breakdowns (opt-in)
+- Learning from user's accepted/rejected patterns over time
+- Template pattern recognition and suggestion improvements
+
+### Privacy requirements
+
+- All processing happens on-device by default
+- No task content sent to cloud without explicit user opt-in
+- Templates stored locally in SwiftData
+- If cloud AI used, task content encrypted in transit and not retained
+
+---
+
+## 11. Data model
+
+### New models
+
+#### BreakdownTemplate
+
+- `id: UUID` - Unique identifier
+- `name: String` - User-defined template name
+- `keywords: [String]` - Pattern matching keywords
+- `defaultGranularity: Int` - Preferred detail level (1-5)
+- `structure: BreakdownStructure` - Template structure
+- `usageCount: Int` - Number of times applied
+- `lastUsed: Date?` - Last application timestamp
+- `createdAt: Date` - Creation timestamp
+- `updatedAt: Date` - Last modification timestamp
+
+#### BreakdownStructure (Codable)
+
+- `steps: [BreakdownStep]` - Ordered list of steps
+- `isHierarchical: Bool` - Whether steps have substeps
+
+#### BreakdownStep (Codable)
+
+- `title: String` - Step description
+- `substeps: [BreakdownStep]?` - Optional nested steps
+- `estimatedDuration: TimeInterval?` - Optional time estimate
+
+### Existing model changes
+
+#### Item
+
+- No changes required
+
+#### Collection
+
+- `sourceTemplate: UUID?` - Optional reference to template used
+- Existing `isStructured: Bool` already supports plans vs lists
+
+#### CollectionItem
+
+- Existing `parentId`, `position` already support hierarchy
+- No changes required
+
+---
+
+## 12. UX & tone requirements
+
+### Visual design
+
+- Granularity slider with clear labels:
+  - 1: "Just the main steps"
+  - 2: "Moderate detail"
+  - 3: "Step by step"
+  - 4: "Very detailed"
+  - 5: "Tiny micro-steps"
+- Preview breakdown before accepting (scrollable list)
+- Edit inline with drag-to-reorder support
+- Template suggestions appear as non-intrusive cards, not modals
+
+### Tone & messaging
+
+- **Encouraging, not prescriptive:** "Here's one way to break this down" vs "You should do these steps"
+- **No judgment:** Never imply the task is "easy" or "simple"
+- **User control emphasized:** "Review and adjust" vs "Accept"
+- **Celebrate template reuse:** "You've used this pattern before—want to apply it again?"
+
+### Interaction patterns
+
+- Breakdown action available from:
+  - Item detail view (prominent button)
+  - Long-press context menu on item
+  - Swipe action in Capture view
+- Template application is always optional and preview-able
+- Can dismiss breakdown and return to original captured item
+- Undo support for accepting breakdown
+
+### Accessibility
+
+- VoiceOver descriptions for granularity levels
+- Haptic feedback at granularity extremes (1 and 5)
+- Sufficient contrast for preview vs accepted state
+- Keyboard navigation for editing breakdown steps
+
+---
+
+## 13. Risks & mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| On-device AI quality not good enough | H | Extensive testing with real user tasks; fallback to cloud AI as opt-in |
+| Users overwhelmed by breakdown options | M | Default to mid-level granularity; remember last used setting per user |
+| Templates become stale or irrelevant | M | Show last used date; prompt to archive unused templates after 90 days |
+| Generated breakdowns feel generic or unhelpful | H | Allow editing before accepting; learn from user modifications over time |
+| Template matching suggests wrong templates | M | Show confidence score; allow "not this time" option without dismissing forever |
+| Privacy concerns about AI processing task content | H | Clear messaging about on-device processing; explicit opt-in for cloud AI |
+| Feature complexity contradicts "minimal friction" goal | M | Make breakdown optional, never default; extensive UX testing with target users |
+
+---
+
+## 14. Implementation tracking
+
+### Dependencies
+
+- On-device AI framework selection and integration
+- Template storage and retrieval system in SwiftData
+- Pattern matching algorithm for template suggestion
+- Hierarchical CollectionItem creation from breakdown structure
+
+### Complexity estimate
+
+- **High complexity** due to AI integration and template matching logic
+- Estimated 3-4 week implementation for MVP
+- Additional 2 weeks for template management UI and refinement
+
+### Testing requirements
+
+- AI breakdown quality testing with diverse task types
+- Template pattern matching accuracy testing
+- Performance testing for on-device AI response times
+- Accessibility testing for all breakdown interactions
+- User testing with diverse user group for cognitive load validation
+
+---
+
+## 15. Open decisions (tracked)
+
+| Decision | Owner | Status | Notes |
+| --- | --- | --- | --- |
+| On-device AI model selection (Core ML, other) | Engineering | Open | Need to evaluate available models for task decomposition quality |
+| Should templates include estimated time per step? | Product | Open | Helpful but may add pressure; conflicts with "no time pressure" principle |
+| Template sharing between users | Product | Deferred | Community templates could be valuable but adds complexity |
+| How to handle template versioning when user edits | Engineering | Open | Allow template updates vs create new template from edited breakdown |
+| Maximum subtask depth in hierarchy | Product | Open | Unlimited depth may be overwhelming; consider 2-3 level maximum |
+| Should breakdown consider user's current context (time of day, energy)? | Product | Deferred | Interesting but complex; defer to future iteration |
+
+---
+
+## 16. Revision history
+
+| Version | Date | Notes |
+| --- | --- | --- |
+| 1.0 | 2026-01-24 | Initial draft based on user research |

--- a/docs/prds/prd-0008-brain-dump-compiler.md
+++ b/docs/prds/prd-0008-brain-dump-compiler.md
@@ -1,0 +1,403 @@
+---
+id: prd-0008-brain-dump-compiler
+type: product-requirements
+status: draft
+owners:
+  - Offload
+applies_to:
+  - product
+last_updated: 2026-01-24
+related:
+  - adr-0003-adhd-focused-ux-ui-guardrails
+  - prd-0001-product-requirements
+structure_notes:
+  - "Section order: 1. Product overview; 2. Problem statement; 3. Product goals; 4. Non-goals (explicit); 5. Target audience; 6. Success metrics; 7. Core user flows; 8. Functional requirements; 9. Pricing & limits; 10. AI & backend requirements; 11. Data model; 12. UX & tone requirements; 13. Risks & mitigations; 14. Implementation tracking; 15. Open decisions; 16. Revision history."
+---
+
+# Offload — Brain Dump Compiler Enhancement PRD
+
+**Version:** 1.0
+**Date:** 2026-01-24
+**Status:** Draft
+**Owner:** Offload
+
+**Related ADRs:**
+
+- [adr-0003: ADHD-Focused UX/UI Guardrails](../adrs/adr-0003-adhd-focused-ux-ui-guardrails.md)
+- [prd-0001: V1 Product Requirements](prd-0001-product-requirements.md)
+
+---
+
+## 1. Product overview
+
+Brain Dump Compiler transforms rambling, stream-of-consciousness captures into
+organized, actionable items. This feature enhances Offload's existing text/voice
+capture by intelligently detecting and extracting tasks, questions, decisions,
+ideas, and concerns from unstructured brain dumps. It then suggests how to
+categorize each extracted item (plan, list, or reference) and offers to create
+the appropriate structures automatically.
+
+**Key differentiator:** Deeply integrated with Offload's capture-and-organize
+workflow, with smart suggestions for which items become plans vs lists, and
+automatic creation of Collections based on detected patterns. Unlike standalone
+compilation tools, this feature maintains context and enables seamless
+organization.
+
+---
+
+## 2. Problem statement
+
+During mental overload, users often capture everything in one long rambling
+entry—mixing tasks, worries, ideas, and questions. Later, when organizing, they
+face the cognitive burden of re-reading, parsing, and categorizing everything.
+This creates a bottleneck between capture and organization.
+
+**Core user pain:**
+> "I just dumped everything in my head into one long voice note. Now I have to
+> figure out what's actually a task, what's just worry, and what needs follow-up.
+> It feels like starting over."
+
+**Gap in existing productivity tools:**
+
+- Brain dump compilers are standalone tools, not integrated with task management
+- Output is plain text, requires manual copying and organizing
+- Don't suggest categorization (task vs idea vs question)
+- No automatic creation of structures from compiled output
+- Don't learn from user's organization patterns
+
+---
+
+## 3. Product goals
+
+- Reduce cognitive load of organizing rambling captures
+- Automatically detect and extract actionable items from brain dumps
+- Categorize extracted items by type (task, question, decision, idea, concern)
+- Suggest appropriate organization structures (plans, lists, reference notes)
+- Offer one-tap creation of suggested Collections with extracted items
+- Learn from user's organization preferences over time
+- Maintain user control: suggest, preview, never auto-organize
+
+---
+
+## 4. Non-goals (explicit)
+
+- No automatic organization without user approval
+- No rigid categorization rules (user can override AI suggestions)
+- No sentiment analysis or emotional content extraction
+- No therapy or mental health intervention features
+- No automatic deletion of "non-actionable" content
+- No forced separation of braindump into multiple items
+
+---
+
+## 5. Target audience
+
+- Users who capture thoughts in long, unstructured bursts
+- People who need to externalize thoughts rapidly
+- Those who use voice capture extensively and produce lengthy transcriptions
+- Users overwhelmed by the organizing phase after capture
+- People who mix tasks, ideas, and worries in single capture sessions
+
+---
+
+## 6. Success metrics (30-day post-launch)
+
+| Metric ID | Metric | Baseline | Target | Measurement |
+| --- | --- | --- | --- | --- |
+| M-800 | % of captures >100 words that use compiler | TBD | ≥35% | Analytics events |
+| M-801 | % of compiled outputs accepted with minimal edits | TBD | ≥60% | Edit tracking |
+| M-802 | Average time from capture to organized | TBD | -40% | Task timing analysis |
+| M-803 | User satisfaction with categorization accuracy | TBD | ≥4.0/5 | In-app survey |
+| M-804 | % of compiled items that result in Collection creation | TBD | ≥45% | Creation events |
+| M-805 | Compiler feature awareness | TBD | ≥70% | User surveys |
+
+---
+
+## 7. Core user flows
+
+### 7.1 Compile single brain dump
+
+1. User captures long rambling entry (text or voice): "I need to call the doctor
+   about the test results and also remember to pick up milk and I'm worried
+   about the presentation on Friday maybe I should outline it tonight or tomorrow
+   and did I pay the electric bill I can't remember..."
+2. User taps "Compile" action (suggested automatically for captures >75 words)
+3. AI analyzes and extracts distinct items with categories:
+   - **Task:** Call doctor about test results
+   - **Task:** Pick up milk
+   - **Task:** Outline Friday presentation
+   - **Question:** Did I pay the electric bill?
+   - **Concern:** Worried about Friday presentation
+4. AI suggests organization:
+   - "Health & Errands" list (Call doctor, Pick up milk)
+   - "Work - Friday Presentation" plan (Outline presentation, with concern noted)
+   - "Follow-up Questions" list (Electric bill payment check)
+5. User reviews, edits categories/groupings, and approves
+6. Collections created automatically with extracted items linked
+
+### 7.2 Batch compile multiple captures
+
+1. User has accumulated 5-10 short captures over a few hours
+2. User selects multiple items in Capture view
+3. User taps "Compile selected" from context menu
+4. AI analyzes all selected captures as a single context
+5. Follows same extraction and organization flow as 7.1
+6. Original captures remain intact; compiled items are new Collections
+
+### 7.3 Review and refine compilation
+
+1. After compilation, user sees preview of extracted items and suggested structure
+2. User can:
+   - Edit item text or category
+   - Merge similar items
+   - Split items into smaller pieces
+   - Reject items (mark as "just venting, not actionable")
+   - Change suggested Collections
+3. User approves final structure
+4. Original capture is optionally archived or tagged as "compiled"
+
+---
+
+## 8. Functional requirements
+
+| Req ID | Requirement | Priority | User Story |
+| --- | --- | --- | --- |
+| FR-800 | Detect captures >75 words and suggest compilation | Must | US-800 |
+| FR-801 | Extract distinct items from unstructured text | Must | US-801 |
+| FR-802 | Categorize extracted items (task, question, decision, idea, concern) | Must | US-802 |
+| FR-803 | Suggest Collection groupings for extracted items | Must | US-803 |
+| FR-804 | Show preview of compilation with edit capabilities | Must | US-804 |
+| FR-805 | Create Collections automatically from approved compilation | Must | US-805 |
+| FR-806 | Support batch compilation of multiple selected captures | Should | US-806 |
+| FR-807 | Preserve original capture after compilation | Should | US-807 |
+| FR-808 | Learn from user's category and grouping overrides | Should | US-808 |
+| FR-809 | Allow merging similar extracted items | Should | US-809 |
+| FR-810 | Support marking items as "not actionable" | Could | US-810 |
+| FR-811 | Tag original capture as "compiled" with link to results | Could | US-811 |
+| FR-812 | Undo compilation and restore to original state | Could | US-812 |
+
+---
+
+## 9. Pricing & limits (hybrid model)
+
+### Free tier
+
+- 5 compilations per month
+- Unlimited manual organization
+- Basic categorization (task, idea, question)
+
+### Paid tier
+
+- Unlimited compilations
+- Advanced categorization (decision, concern, reference, insight)
+- Learning from organization patterns
+- Batch compilation of multiple captures
+- Priority processing
+
+**Rationale:** Compilation is a power feature that requires significant AI
+processing. Free tier provides taste of value; paid tier unlocks full utility
+for heavy users.
+
+---
+
+## 10. AI & backend requirements
+
+### On-device AI (Phase 1 - Offline)
+
+- Natural language processing for entity extraction
+- Sentence boundary detection and topic segmentation
+- Categorization model trained on common neurodivergent thought patterns
+- Context window sufficient for ~1000 word captures
+- Response time <5 seconds for typical brain dump
+
+### Backend AI (Phase 2+ - Optional)
+
+- Cloud-based LLM for higher quality extraction and categorization
+- Learning from user's accepted/rejected categorizations
+- Pattern recognition for recurring themes and organization preferences
+- Support for longer captures (>1000 words)
+
+### Privacy requirements
+
+- All processing happens on-device by default
+- No capture content sent to cloud without explicit opt-in
+- If cloud AI used, content encrypted in transit and not retained
+- Extracted items stored locally in SwiftData only
+
+---
+
+## 11. Data model
+
+### New models
+
+#### CompilationResult
+
+- `id: UUID` - Unique identifier
+- `sourceItemIds: [UUID]` - Original capture(s) compiled
+- `extractedItems: [ExtractedItem]` - Parsed items with categories
+- `suggestedCollections: [SuggestedCollection]` - Recommended groupings
+- `userModifications: [UserEdit]` - Track overrides for learning
+- `status: CompilationStatus` - draft, approved, rejected
+- `createdAt: Date` - Compilation timestamp
+
+#### ExtractedItem (Codable)
+
+- `id: UUID` - Unique identifier
+- `text: String` - Item content
+- `category: ItemCategory` - task, question, decision, idea, concern, reference
+- `confidence: Float` - AI confidence in categorization (0-1)
+- `originalContext: String` - Surrounding text from source
+- `userOverride: ItemCategory?` - If user changed category
+
+#### ItemCategory (Enum)
+
+- `task` - Actionable to-do
+- `question` - Needs answer or follow-up
+- `decision` - Choice to be made
+- `idea` - Creative thought or suggestion
+- `concern` - Worry or anxiety (acknowledged, not necessarily actionable)
+- `reference` - Information to remember
+
+#### SuggestedCollection (Codable)
+
+- `name: String` - Suggested collection name
+- `isStructured: Bool` - Plan (true) vs list (false)
+- `itemIds: [UUID]` - Extracted items to include
+- `rationale: String` - Why these items grouped together
+
+#### UserEdit (Codable)
+
+- `itemId: UUID` - Which item was modified
+- `editType: EditType` - category_change, merge, split, reject
+- `fromValue: String?` - Original value
+- `toValue: String?` - New value
+- `timestamp: Date` - When edit occurred
+
+#### CompilationStatus (Enum)
+
+- `draft` - User still reviewing
+- `approved` - User accepted and Collections created
+- `rejected` - User dismissed compilation
+
+### Existing model changes
+
+#### Item
+
+- `compilationId: UUID?` - Link to CompilationResult if item was compiled
+- `isCompiled: Bool` - Flag for UI filtering
+
+#### Collection
+
+- `sourceCompilation: UUID?` - Link to CompilationResult if created from compilation
+
+---
+
+## 12. UX & tone requirements
+
+### Visual design
+
+- Compilation preview uses card-based layout with clear category labels
+- Category badges use distinct colors:
+  - Task: Blue
+  - Question: Purple
+  - Decision: Orange
+  - Idea: Green
+  - Concern: Yellow
+  - Reference: Gray
+- Suggested Collections appear as grouped cards with Collection name headers
+- Drag-and-drop support for moving items between suggested Collections
+- Clear "Approve" and "Edit more" actions
+
+### Tone & messaging
+
+- **Non-judgmental about content:** Never label concerns as "irrational" or ideas as "unrealistic"
+- **Encouraging:** "I found [X] actionable items in your brain dump"
+- **Acknowledging mixed content:** "Some of this is tasks, some is just thoughts to acknowledge"
+- **User control:** "Review and adjust the categories—I'm just making my best guess"
+- **Celebration:** "Nice brain dump! This covers a lot of ground."
+
+### Interaction patterns
+
+- Automatic suggestion for compilation appears as non-intrusive banner
+- User can dismiss "Compile?" suggestion and it won't re-appear for that capture
+- Preview state allows extensive editing before commitment
+- Can save compilation draft and return later
+- Undo available for 30 seconds after approval
+- Original capture optionally archived (not deleted) after compilation
+
+### Accessibility
+
+- VoiceOver reads category labels clearly
+- Color is not the only indicator of category (icons + text)
+- Sufficient touch targets for category editing
+- Keyboard navigation for all editing actions
+- High contrast mode support
+
+---
+
+## 13. Risks & mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Categorization accuracy too low, users lose trust | H | Extensive training on neurodivergent thought patterns; show confidence scores; easy override |
+| Users feel judged by "concern" vs "task" categorization | H | Careful messaging; emphasize concerns are valid; option to disable concern detection |
+| Long brain dumps exceed AI processing capacity | M | Chunk long captures into segments; show progress indicator |
+| Compilation feels like "extra work" instead of helpful | H | Make preview editing very fast and intuitive; show time savings metrics |
+| Feature complexity contradicts "minimal friction" goal | M | Make compilation entirely optional; never interrupt capture flow |
+| Privacy concerns about AI reading personal thoughts | H | Clear on-device processing messaging; sensitive content warnings; opt-in cloud |
+| Over-extraction creates too many items, overwhelming user | M | Merge similar items automatically; adjustable extraction sensitivity |
+
+---
+
+## 14. Implementation tracking
+
+### Dependencies
+
+- Natural language processing framework for entity extraction
+- Categorization model training dataset
+- Preview/editing UI for compilation results
+- Learning system to track user overrides and improve suggestions
+- Batch processing for multiple selected captures
+
+### Related features
+
+- Depends on existing capture system (text and voice)
+- Integrates with Collection creation workflows
+- May influence future AI organization features
+
+### Complexity estimate
+
+- **High complexity** due to NLP requirements and learning system
+- Estimated 4-5 week implementation for MVP
+- Additional 2 weeks for batch compilation and learning refinements
+- Requires significant testing with diverse brain dump content
+
+### Testing requirements
+
+- Categorization accuracy testing with real user brain dumps
+- Edge case testing (very long dumps, short dumps, single topic)
+- Performance testing for on-device NLP processing
+- Accessibility testing for category editing interactions
+- User testing with diverse user group for cognitive load validation
+- Privacy testing to ensure no content leakage
+
+---
+
+## 15. Open decisions (tracked)
+
+| Decision | Owner | Status | Notes |
+| --- | --- | --- | --- |
+| Should "concern" category be surfaced prominently or downplayed? | Product | Open | Risk of making users feel judged vs helping acknowledge worries |
+| Automatically archive original capture after compilation? | Product | Open | Pros: cleaner inbox. Cons: loss of original context |
+| How to handle brain dumps that are purely emotional venting? | Product | Open | Extract zero items and acknowledge? Suggest journaling feature? |
+| Maximum number of extracted items before suggesting split | Engineering | Open | Too many items is overwhelming; what's the threshold? |
+| Should compilation learning be explicit or implicit? | Product | Open | Show "I noticed you usually put X in plans" vs silent learning |
+| Integration with future journaling or reflection features | Product | Deferred | Concerns/ideas might feed into separate reflection workflows |
+
+---
+
+## 16. Revision history
+
+| Version | Date | Notes |
+| --- | --- | --- |
+| 1.0 | 2026-01-24 | Initial draft based on user research |

--- a/docs/prds/prd-0009-recurring-task-intelligence.md
+++ b/docs/prds/prd-0009-recurring-task-intelligence.md
@@ -1,0 +1,440 @@
+---
+id: prd-0009-recurring-task-intelligence
+type: product-requirements
+status: draft
+owners:
+  - Offload
+applies_to:
+  - product
+last_updated: 2026-01-24
+related:
+  - adr-0003-adhd-focused-ux-ui-guardrails
+  - prd-0001-product-requirements
+structure_notes:
+  - "Section order: 1. Product overview; 2. Problem statement; 3. Product goals; 4. Non-goals (explicit); 5. Target audience; 6. Success metrics; 7. Core user flows; 8. Functional requirements; 9. Pricing & limits; 10. AI & backend requirements; 11. Data model; 12. UX & tone requirements; 13. Risks & mitigations; 14. Implementation tracking; 15. Open decisions; 16. Revision history."
+---
+
+# Offload — Recurring Task Intelligence PRD
+
+**Version:** 1.0
+**Date:** 2026-01-24
+**Status:** Draft
+**Owner:** Offload
+
+**Related ADRs:**
+
+- [adr-0003: ADHD-Focused UX/UI Guardrails](../adrs/adr-0003-adhd-focused-ux-ui-guardrails.md)
+- [prd-0001: V1 Product Requirements](prd-0001-product-requirements.md)
+
+---
+
+## 1. Product overview
+
+Recurring Task Intelligence detects natural patterns in completed tasks and
+gently suggests (never enforces) when similar tasks might be relevant again.
+Unlike traditional recurring task systems that impose rigid schedules, this
+feature learns from actual completion behavior and provides context-aware,
+shame-free nudges based on the user's real rhythms.
+
+**Key differentiator from traditional task managers:**
+
+- No rigid schedules or forced recurrence
+- Learns from actual completion patterns, not user-declared intentions
+- Gentle suggestions instead of overdue notifications
+- Smart snooze that learns from dismissal patterns
+- Zero guilt for skipped or delayed tasks
+
+---
+
+## 2. Problem statement
+
+People struggle with traditional recurring task systems that impose rigid
+schedules. When they miss a scheduled task, they feel guilty and overwhelmed.
+Yet many tasks do recur naturally (groceries, laundry, medication refills) and
+would benefit from gentle reminders based on actual patterns rather than
+arbitrary schedules.
+
+**Core user pain:**
+> "I know I need to buy groceries every week, but sometimes it's 5 days,
+> sometimes it's 10 days. Recurring task apps make me feel like a failure when
+> I don't do it 'on schedule.' I need something that notices my patterns without
+> judging me."
+
+**Gap in existing productivity tools:**
+
+- Many neurodivergent-focused tools lack calendar or recurrence features
+- Traditional task managers use rigid schedules with "overdue" pressure
+- Existing tools don't learn from actual completion behavior
+- Missing a recurring task creates guilt and notification pile-up
+
+---
+
+## 3. Product goals
+
+- Detect natural recurrence patterns from completed tasks
+- Suggest task recurrence based on learned patterns, not rigid schedules
+- Provide gentle, shame-free nudges without "overdue" language
+- Learn from snooze/dismiss patterns to refine timing
+- Support both regular patterns (weekly groceries) and irregular patterns (quarterly tasks)
+- Maintain "no guilt, no pressure" principle from ADR-0003
+- Give users full control to accept, modify, or ignore suggestions
+
+---
+
+## 4. Non-goals (explicit)
+
+- No rigid recurring task schedules
+- No "overdue" indicators or red warnings
+- No streak tracking or completion pressure
+- No calendar integration or time-based reminders (in v1)
+- No automatic task creation without user approval
+- No nagging or escalating notifications
+- No shared or collaborative recurring tasks
+
+---
+
+## 5. Target audience
+
+- People who struggle with rigid schedules
+- Users who have naturally recurring tasks but resist formal scheduling
+- Those who feel guilt or shame from traditional recurring task systems
+- Users who complete similar tasks irregularly but predictably
+- People who want helpful suggestions without pressure
+
+---
+
+## 6. Success metrics (30-day post-launch)
+
+| Metric ID | Metric | Baseline | Target | Measurement |
+| --- | --- | --- | --- | --- |
+| M-900 | % of users with detected patterns | TBD | ≥40% | Pattern detection events |
+| M-901 | % of pattern suggestions accepted | TBD | ≥50% | Suggestion acceptance rate |
+| M-902 | Average time between pattern detection and task completion | TBD | <3 days | Timing analysis |
+| M-903 | User satisfaction with suggestion timing | TBD | ≥4.3/5 | In-app survey |
+| M-904 | % of suggestions snoozed (lower is better) | TBD | <25% | Snooze rate |
+| M-905 | % of users who report feeling guilty from suggestions | TBD | <5% | User surveys |
+
+---
+
+## 7. Core user flows
+
+### 7.1 Pattern detection and first suggestion
+
+1. User has completed "Buy groceries" task 4 times over past 30 days
+2. System detects pattern: ~7 day intervals (range: 5-9 days)
+3. 6 days after last completion, gentle suggestion appears in Capture view:
+   "You usually buy groceries around this time. Want to add it to your list?"
+4. User can:
+   - Accept (creates new item)
+   - Snooze (ask again in 2 days)
+   - Dismiss (not this time)
+   - Never suggest this pattern (opts out permanently)
+5. If accepted, new "Buy groceries" item created in Capture
+
+### 7.2 Learning from dismissal patterns
+
+1. User dismisses "Buy groceries" suggestion
+2. User completes "Buy groceries" 3 days later
+3. System learns: user's actual interval was 9 days, not 6
+4. Next suggestion appears at 8-9 day mark instead of 6
+5. Over time, confidence interval narrows to user's actual rhythm
+
+### 7.3 Irregular pattern detection
+
+1. User completes "Renew car registration" once
+2. 11 months later, system suggests: "It's been about a year since you renewed
+   car registration. Might be time again?"
+3. Confidence indicator shows "low confidence - only happened once before"
+4. User can accept, provide context ("Actually it's every 2 years"), or dismiss
+
+### 7.4 Pattern refinement
+
+1. User sees pattern suggestion
+2. User taps "Edit pattern" instead of accept/dismiss
+3. UI shows detected interval and confidence
+4. User can:
+   - Adjust interval ("Actually it's every 10-14 days, not weekly")
+   - Add context ("Only in winter" or "Only when I run out")
+   - Disable pattern entirely
+5. System learns from adjustment and applies to future suggestions
+
+### 7.5 Viewing all patterns
+
+1. User navigates to Settings → Task Patterns
+2. Sees list of detected patterns with:
+   - Task name
+   - Average interval
+   - Last completed date
+   - Next suggestion date (if active)
+   - Confidence level
+3. Can edit, disable, or manually trigger any pattern
+
+---
+
+## 8. Functional requirements
+
+| Req ID | Requirement | Priority | User Story |
+| --- | --- | --- | --- |
+| FR-900 | Detect patterns from completed task history (min 3 completions) | Must | US-900 |
+| FR-901 | Calculate average interval and confidence range | Must | US-901 |
+| FR-902 | Surface gentle suggestions at learned intervals | Must | US-902 |
+| FR-903 | Provide accept, snooze, dismiss, and opt-out options | Must | US-903 |
+| FR-904 | Learn from snooze/dismiss timing to refine intervals | Must | US-904 |
+| FR-905 | Support both regular (weekly) and irregular (yearly) patterns | Should | US-905 |
+| FR-906 | Allow manual pattern refinement (edit intervals) | Should | US-906 |
+| FR-907 | Show all detected patterns in Settings | Should | US-907 |
+| FR-908 | Display confidence level for pattern suggestions | Should | US-908 |
+| FR-909 | Support manual triggering of pattern suggestions | Could | US-909 |
+| FR-910 | Detect seasonal or contextual patterns | Could | US-910 |
+| FR-911 | Pattern sharing between users | Won't | - |
+| FR-912 | Time-based reminders or notifications | Won't | - |
+
+---
+
+## 9. Pricing & limits (hybrid model)
+
+### Free tier
+
+- Up to 5 active recurring patterns
+- Basic pattern detection (regular intervals only)
+- Manual pattern management
+
+### Paid tier
+
+- Unlimited active patterns
+- Advanced pattern detection (irregular, seasonal, contextual)
+- Learning from dismissal patterns
+- Pattern suggestions with confidence indicators
+- Historical pattern analytics
+
+**Rationale:** Pattern detection is a quality-of-life feature. Free tier
+provides core value for essential recurring tasks; paid tier unlocks full
+intelligence for power users.
+
+---
+
+## 10. AI & backend requirements
+
+### On-device processing (Phase 1)
+
+- Pattern detection algorithm analyzing completion timestamps
+- Statistical analysis for interval calculation and confidence ranges
+- Simple machine learning for refinement from user behavior
+- No external API calls required
+
+### Cloud-based enhancements (Phase 2+ - Optional)
+
+- More sophisticated pattern recognition (seasonal, contextual)
+- Cross-user pattern insights (anonymized)
+- Predictive modeling for irregular tasks
+- Natural language pattern descriptions
+
+### Privacy requirements
+
+- All pattern detection happens on-device
+- Completion history never leaves device
+- If cloud features opt-in, only anonymized aggregate data shared
+- User can delete all pattern data at any time
+
+---
+
+## 11. Data model
+
+### New models
+
+#### TaskPattern
+
+- `id: UUID` - Unique identifier
+- `taskSignature: String` - Normalized task description (for matching)
+- `completionHistory: [Date]` - Timestamps of completions
+- `averageInterval: TimeInterval` - Mean time between completions
+- `intervalRange: ClosedRange<TimeInterval>` - Min and max observed intervals
+- `confidence: Float` - Confidence in pattern (0-1), based on consistency
+- `nextSuggestedDate: Date` - When to show next suggestion
+- `isActive: Bool` - User can disable pattern
+- `userAdjustments: [PatternAdjustment]` - Manual refinements
+- `dismissalHistory: [DismissalEvent]` - Track snoozes and dismissals for learning
+- `createdAt: Date` - When pattern first detected
+- `updatedAt: Date` - Last calculation update
+
+#### PatternAdjustment (Codable)
+
+- `timestamp: Date` - When adjustment made
+- `adjustmentType: AdjustmentType` - interval, context, disable
+- `oldValue: String?` - Previous value
+- `newValue: String` - New value
+- `rationale: String?` - User-provided reason
+
+#### AdjustmentType (Enum)
+
+- `interval` - Changed expected recurrence timing
+- `context` - Added conditional context
+- `disable` - Turned off pattern
+- `enable` - Re-enabled pattern
+
+#### DismissalEvent (Codable)
+
+- `timestamp: Date` - When dismissed or snoozed
+- `eventType: DismissalType` - snoozed, dismissed, opted_out
+- `actualCompletionDate: Date?` - If user completed task after dismissal
+- `daysDifference: Int?` - Difference from suggested date
+
+#### DismissalType (Enum)
+
+- `snoozed` - Ask again later
+- `dismissed` - Not this time
+- `opted_out` - Never suggest this pattern
+
+#### SuggestionEvent (Codable)
+
+- `patternId: UUID` - Which pattern triggered suggestion
+- `suggestedDate: Date` - When suggestion shown
+- `userResponse: SuggestionResponse` - What user did
+- `createdItemId: UUID?` - If accepted, the created item
+
+#### SuggestionResponse (Enum)
+
+- `accepted` - Created item from suggestion
+- `snoozed` - Delayed suggestion
+- `dismissed` - Ignored suggestion
+- `opted_out` - Disabled pattern
+- `no_response` - Suggestion expired without interaction
+
+### Existing model changes
+
+#### Item
+
+- `sourcePattern: UUID?` - Link to TaskPattern if created from suggestion
+- `completedAt: Date?` - Track completion for pattern detection
+
+#### Collection
+
+- No changes required
+
+---
+
+## 12. UX & tone requirements
+
+### Visual design
+
+- Pattern suggestions appear as gentle, dismissible cards in Capture view
+- Not modal, not intrusive—just a suggestion among captures
+- Confidence indicator as subtle visual element (not numerical percentage)
+  - High confidence: Solid icon
+  - Medium confidence: Outlined icon
+  - Low confidence: Dotted icon with "First time suggesting this"
+- Suggestion cards use calm colors (not attention-grabbing red/orange)
+- Snooze action shows next suggestion date
+- Pattern list in Settings shows visual timeline of completions
+
+### Tone & messaging
+
+- **Gentle, never demanding:** "You usually [task] around this time" not "Time to [task]!"
+- **No guilt:** "Want to add it to your list?" not "You should do this"
+- **Acknowledging uncertainty:** "Based on your pattern..." not "You must..."
+- **Respecting dismissal:** "No problem, I'll check again later" not "Reminder postponed"
+- **Learning language:** "I noticed you did this X days later than I suggested—I'll adjust"
+- **No "overdue":** Never use words like late, behind, overdue, missed
+- **Celebration without pressure:** "Nice! I'll remember this for next time"
+
+### Example suggestion messages
+
+**High confidence (weekly groceries):**
+> "You usually buy groceries around this time. Want to add it to your list?"
+
+**Medium confidence (monthly task):**
+> "It's been about 3 weeks since you [task]. Might be time again?"
+
+**Low confidence (first repeat):**
+> "It's been about a year since you renewed car registration. Might be time
+> again? (This is my first time suggesting this, so I might be off)"
+
+**After dismissal learning:**
+> "I suggested this a few days ago, but you did it today instead. I'll remember
+> that you prefer a longer interval."
+
+### Interaction patterns
+
+- Suggestion cards can be swiped away (dismiss)
+- Tap suggestion to see full pattern details and options
+- Snooze offers smart defaults: "Ask me in 2 days" or custom date
+- Accept creates item immediately with optional customization
+- Opt-out is available but requires confirmation to prevent accidental taps
+- All suggestions auto-dismiss after 7 days if no response
+
+### Accessibility
+
+- VoiceOver clearly describes suggestion vs regular item
+- Haptic feedback on accept (gentle success haptic)
+- Sufficient contrast for confidence indicators
+- Large touch targets for accept/snooze/dismiss
+- Keyboard navigation for all suggestion interactions
+
+---
+
+## 13. Risks & mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Pattern detection too aggressive, annoying users | H | Require minimum 3 completions; easy opt-out; learn from dismissals |
+| Suggestions feel like pressure, contradicting "no guilt" goal | H | Careful tone and messaging; extensive ADHD user testing; anonymous feedback |
+| Pattern matching too loose, suggests wrong tasks | M | Use task signature normalization; show confidence; easy dismissal |
+| Users never complete tasks, so no patterns detected | M | Feature is optional; value proposition clear for those who do complete tasks |
+| Privacy concerns about tracking completion behavior | M | Clear on-device messaging; no external data sharing; user-controlled deletion |
+| Feature complexity adds cognitive load | M | Suggestions are passive, never interrupt; can disable entirely in Settings |
+| Users rely on suggestions and miss tasks without them | L | Suggestions are supplements, not reminders; educate on feature purpose |
+
+---
+
+## 14. Implementation tracking
+
+### Dependencies
+
+- Item completion tracking (need `completedAt` timestamp)
+- Pattern detection algorithm
+- Suggestion display UI in Capture view
+- Learning system for refinement from user behavior
+- Settings UI for pattern management
+
+### Related features
+
+- Complements existing capture and organization workflows
+- May inform future scheduling or planning features
+- Could integrate with future notification system (opt-in)
+
+### Complexity estimate
+
+- **Medium complexity** for pattern detection algorithm
+- **Low complexity** for basic UI
+- Estimated 2-3 week implementation for MVP
+- Additional 1-2 weeks for learning refinements and Settings UI
+
+### Testing requirements
+
+- Pattern detection accuracy testing with diverse completion histories
+- Edge case testing (irregular patterns, single completions, gaps)
+- Performance testing for pattern calculation on large datasets
+- Tone and messaging testing with diverse user group
+- A/B testing of suggestion messaging to minimize guilt response
+- Accessibility testing for all suggestion interactions
+
+---
+
+## 15. Open decisions (tracked)
+
+| Decision | Owner | Status | Notes |
+| --- | --- | --- | --- |
+| Minimum completions to detect pattern (3, 4, or 5?) | Product | Open | Lower = more suggestions (possibly annoying); higher = fewer false positives |
+| Should suggestions appear as notifications or in-app only? | Product | Deferred | Notifications risky for "no pressure" goal; defer to future iteration |
+| How to handle tasks that change over time (e.g., "Buy groceries" vs "Restock kitchen")? | Engineering | Open | Need task signature normalization strategy |
+| Show all suggestions in one place vs scattered among captures? | Design | Open | Pros/cons of dedicated "Suggestions" view vs inline |
+| Support for conditional patterns (e.g., "Only in winter")? | Product | Deferred | Interesting but complex; defer to Phase 2 |
+| Integration with future calendar features | Product | Deferred | If calendar added, patterns could inform it |
+
+---
+
+## 16. Revision history
+
+| Version | Date | Notes |
+| --- | --- | --- |
+| 1.0 | 2026-01-24 | Initial draft based on user research |

--- a/docs/prds/prd-0010-tone-assistant.md
+++ b/docs/prds/prd-0010-tone-assistant.md
@@ -1,0 +1,436 @@
+---
+id: prd-0010-tone-assistant
+type: product-requirements
+status: draft
+owners:
+  - Offload
+applies_to:
+  - product
+last_updated: 2026-01-24
+related:
+  - adr-0003-adhd-focused-ux-ui-guardrails
+  - prd-0001-product-requirements
+structure_notes:
+  - "Section order: 1. Product overview; 2. Problem statement; 3. Product goals; 4. Non-goals (explicit); 5. Target audience; 6. Success metrics; 7. Core user flows; 8. Functional requirements; 9. Pricing & limits; 10. AI & backend requirements; 11. Data model; 12. UX & tone requirements; 13. Risks & mitigations; 14. Implementation tracking; 15. Open decisions; 16. Revision history."
+---
+
+# Offload — Tone Assistant PRD
+
+**Version:** 1.0
+**Date:** 2026-01-24
+**Status:** Draft
+**Owner:** Offload
+
+**Related ADRs:**
+
+- [adr-0003: ADHD-Focused UX/UI Guardrails](../adrs/adr-0003-adhd-focused-ux-ui-guardrails.md)
+- [prd-0001: V1 Product Requirements](prd-0001-product-requirements.md)
+
+---
+
+## 1. Product overview
+
+Tone Assistant helps users transform raw captured thoughts into appropriately
+toned communication for different contexts. Whether turning a frustrated brain
+dump into a professional email, a scattered idea into a clear message, or an
+anxious ramble into a concise text, this feature bridges the gap between
+authentic internal voice and socially expected communication.
+
+**Key differentiator from Goblin Tools' Formalizer:**
+
+- Integrated with Offload's capture workflow (not standalone tool)
+- Multiple tone options beyond formal (friendly, concise, empathetic, direct)
+- Preview and iterate before committing
+- Save tone presets for frequently-used communication styles
+- Works on captured items, maintaining privacy and context
+
+---
+
+## 2. Problem statement
+
+Neurodivergent individuals often struggle with code-switching between their
+authentic internal voice and socially expected communication styles. Writing
+professional emails, texts to authority figures, or even friendly messages can
+be paralyzing when unsure of the "right" tone. This leads to avoidance,
+over-editing, or miscommunication.
+
+**Core user pain:**
+> "I know what I want to say, but I can't figure out how to say it
+> professionally without sounding stiff or rude. I spend 30 minutes rewriting
+> a 3-sentence email."
+
+**Gap in existing tools (Goblin Tools):**
+
+- Formalizer is standalone, requires copy-paste workflow
+- Limited tone options (just formality levels)
+- No integration with task/capture workflow
+- No ability to save preferences or iterate on transformations
+- Output is plain text with no further action
+
+---
+
+## 3. Product goals
+
+- Reduce anxiety around written communication
+- Transform captured thoughts into context-appropriate messages
+- Provide multiple tone options (formal, friendly, concise, empathetic, direct)
+- Enable preview and iteration before sharing
+- Support saving tone presets for recurring communication needs
+- Integrate with share/copy workflows for easy sending
+- Maintain user's original voice while adapting tone
+- Work offline with on-device processing for privacy
+
+---
+
+## 4. Non-goals (explicit)
+
+- No automatic sending or sharing (user always controls)
+- No grammar/spelling checking (tone only)
+- No real-time writing assistance (operates on completed captures)
+- No analysis of received messages (outbound communication only)
+- No language translation
+- No sentiment manipulation (maintains user's intent)
+
+---
+
+## 5. Target audience
+
+- Autistic individuals who struggle with social communication expectations
+- People with ADHD who write stream-of-consciousness and need structure
+- Anyone with communication anxiety
+- Users who overthink message tone and spend excessive time editing
+- People who mask heavily and need help with code-switching
+
+---
+
+## 6. Success metrics (30-day post-launch)
+
+| Metric ID | Metric | Baseline | Target | Measurement |
+| --- | --- | --- | --- | --- |
+| M-1000 | % of captures that use tone transformation | TBD | ≥15% | Analytics events |
+| M-1001 | % of transformations that result in share/copy | TBD | ≥70% | Action completion rate |
+| M-1002 | User satisfaction with tone quality | TBD | ≥4.4/5 | In-app survey |
+| M-1003 | Average iterations per transformation | TBD | <2 | Iteration tracking |
+| M-1004 | % of users who save tone presets | TBD | ≥25% | Preset creation events |
+| M-1005 | Reduction in communication avoidance | TBD | -35% | User self-report |
+
+---
+
+## 7. Core user flows
+
+### 7.1 Transform capture to email
+
+1. User captures frustrated thought: "I'm really annoyed that the package still
+   hasn't arrived and I paid for 2-day shipping like a week ago"
+2. User taps "Adjust tone" action on captured item
+3. User selects target tone: "Professional"
+4. AI generates transformation:
+   > "I wanted to follow up regarding my order that was scheduled for 2-day
+   > shipping. It's been approximately one week and I haven't received
+   > confirmation of delivery. Could you please provide an update on the status?"
+5. User reviews, optionally tweaks wording
+6. User taps "Copy" or "Share" to send via email/message app
+
+### 7.2 Quick tone adjustments with presets
+
+1. User captures: "Tell mom I can't make it to dinner Sunday, something came up
+   with work"
+2. User taps "Adjust tone" and sees saved preset "Family - Apologetic"
+3. User applies preset, AI generates:
+   > "Hi Mom, I'm so sorry but I won't be able to make Sunday dinner. Something
+   > urgent came up at work. I really wish I could be there. Can we reschedule
+   > for next weekend?"
+4. User approves and shares directly to messages
+
+### 7.3 Iterate on tone transformation
+
+1. User generates initial transformation with "Friendly" tone
+2. Result feels too casual for the recipient
+3. User taps "Adjust" and changes to "Friendly-Professional"
+4. Reviews new version, closer but still not quite right
+5. User manually edits key phrase while keeping rest of transformation
+6. User saves final version and sends
+
+### 7.4 Save tone preset
+
+1. User completes transformation they're happy with
+2. User taps "Save as preset"
+3. User names preset: "Professors - Respectful inquiry"
+4. User optionally adds keywords: "professor, teacher, academic, school"
+5. Preset saved with tone parameters and example
+6. Future similar contexts suggest: "Use 'Professors - Respectful inquiry'?"
+
+### 7.5 Multiple tone previews
+
+1. User captures message and taps "Adjust tone"
+2. Instead of selecting one tone, user taps "Show all options"
+3. AI generates 3 versions simultaneously:
+   - Formal
+   - Friendly
+   - Concise
+4. User reviews side-by-side and selects preferred version
+5. User can further refine selected version
+
+---
+
+## 8. Functional requirements
+
+| Req ID | Requirement | Priority | User Story |
+| --- | --- | --- | --- |
+| FR-1000 | Provide tone adjustment action for captured items | Must | US-1000 |
+| FR-1001 | Support multiple tone options (formal, friendly, concise, empathetic, direct) | Must | US-1001 |
+| FR-1002 | Generate tone transformation while preserving user's intent | Must | US-1002 |
+| FR-1003 | Show preview before committing transformation | Must | US-1003 |
+| FR-1004 | Enable iteration on transformation (regenerate with different tone) | Must | US-1004 |
+| FR-1005 | Provide copy and share actions for transformed text | Must | US-1005 |
+| FR-1006 | Support saving tone presets with names and keywords | Should | US-1006 |
+| FR-1007 | Suggest relevant presets based on capture content | Should | US-1007 |
+| FR-1008 | Show multiple tone previews simultaneously | Should | US-1008 |
+| FR-1009 | Allow manual editing of transformed text before sharing | Should | US-1009 |
+| FR-1010 | Preset management UI (view, edit, delete, rename) | Should | US-1010 |
+| FR-1011 | Track transformation history on item | Could | US-1011 |
+| FR-1012 | Compare original vs transformed side-by-side | Could | US-1012 |
+| FR-1013 | Preset sharing between users | Won't | - |
+| FR-1014 | Real-time tone adjustment as user types | Won't | - |
+
+---
+
+## 9. Pricing & limits (hybrid model)
+
+### Free tier
+
+- 10 tone transformations per month
+- 3 saved presets
+- Basic tone options (formal, friendly, concise)
+- Single transformation preview
+
+### Paid tier
+
+- Unlimited tone transformations
+- Unlimited presets
+- Advanced tone options (empathetic, direct, nuanced blends)
+- Multi-tone preview (see all options at once)
+- Transformation history
+- Priority processing
+
+**Rationale:** Tone transformation is valuable for specific high-anxiety
+communications. Free tier enables critical use cases; paid tier for frequent
+communicators and power users.
+
+---
+
+## 10. AI & backend requirements
+
+### On-device AI (Phase 1 - Offline)
+
+- Language model capable of style transfer while preserving meaning
+- Support for multiple tone parameters and blending
+- Context window sufficient for ~500 word messages
+- Response time <3 seconds for transformation
+- Fallback gracefully if unavailable
+
+### Backend AI (Phase 2+ - Optional)
+
+- Cloud-based LLM for higher quality transformations (opt-in)
+- Learning from user's accepted/rejected transformations
+- Preset suggestion improvements based on usage patterns
+- Support for longer documents
+
+### Privacy requirements
+
+- All processing happens on-device by default
+- Message content never sent to cloud without explicit opt-in
+- Presets stored locally in SwiftData
+- If cloud AI used, content encrypted in transit and not retained
+- No analysis of message recipients or context
+
+---
+
+## 11. Data model
+
+### New models
+
+#### TonePreset
+
+- `id: UUID` - Unique identifier
+- `name: String` - User-defined preset name
+- `keywords: [String]` - Pattern matching keywords
+- `toneParameters: ToneParameters` - Tone configuration
+- `exampleInput: String?` - Optional example original text
+- `exampleOutput: String?` - Optional example transformation
+- `usageCount: Int` - Number of times applied
+- `lastUsed: Date?` - Last application timestamp
+- `createdAt: Date` - Creation timestamp
+- `updatedAt: Date` - Last modification timestamp
+
+#### ToneParameters (Codable)
+
+- `baseStyle: ToneStyle` - Primary tone
+- `formalityLevel: Int` - 1-5 scale
+- `friendlinessLevel: Int` - 1-5 scale
+- `concisenessLevel: Int` - 1-5 scale
+- `empathyLevel: Int?` - Optional 1-5 scale
+- `preserveHumor: Bool` - Maintain jokes/lightness
+
+#### ToneStyle (Enum)
+
+- `formal` - Professional, structured
+- `friendly` - Warm, approachable
+- `concise` - Brief, to the point
+- `empathetic` - Understanding, validating
+- `direct` - Clear, straightforward
+- `neutral` - Balanced, middle ground
+
+#### ToneTransformation
+
+- `id: UUID` - Unique identifier
+- `sourceItemId: UUID` - Original captured item
+- `originalText: String` - User's original capture
+- `transformedText: String` - AI-generated transformation
+- `toneUsed: ToneParameters` - Tone settings applied
+- `presetUsed: UUID?` - If preset was applied
+- `userEdits: String?` - Manual modifications after transformation
+- `wasShared: Bool` - Whether user copied/shared result
+- `createdAt: Date` - Transformation timestamp
+
+### Existing model changes
+
+#### Item
+
+- `transformationHistory: [UUID]?` - Links to ToneTransformation records
+- No required changes, transformations tracked separately
+
+---
+
+## 12. UX & tone requirements
+
+### Visual design
+
+- Tone selector as horizontal scrolling chips (not overwhelming dropdown)
+- Preview shows original and transformed side-by-side on larger screens
+- Clear visual distinction between preview and committed transformation
+- Preset suggestions appear as dismissible chips above tone selector
+- Copy and share buttons prominent after transformation
+- Iteration controls (regenerate, adjust tone) easily accessible
+
+### Tone option labels and descriptions
+
+- **Formal:** "Professional and structured" - For work, official requests
+- **Friendly:** "Warm and approachable" - For casual but polite communication
+- **Concise:** "Brief and to the point" - For busy recipients, quick updates
+- **Empathetic:** "Understanding and validating" - For sensitive situations
+- **Direct:** "Clear and straightforward" - For clarity, no ambiguity
+- **Neutral:** "Balanced middle ground" - When unsure which tone to use
+
+### Tone & messaging
+
+- **Non-judgmental about original:** Never imply original text was "wrong"
+- **Emphasize choice:** "Here's one way to phrase this" not "You should say this"
+- **Acknowledge uncertainty:** "This is my interpretation of a [tone] version"
+- **User control:** "You can edit any part of this before sharing"
+- **Privacy assurance:** "This happens on your device—nothing is shared"
+
+### Example transformations
+
+**Original (frustrated):**
+> "Why hasn't anyone responded to my email from 3 days ago? This is ridiculous."
+
+**Formal transformation:**
+> "I wanted to follow up on the email I sent on [date]. I understand you may be
+> busy, but I would appreciate an update when you have a moment."
+
+**Direct transformation:**
+> "I'm following up on my email from [date] and would like a response. When can
+> I expect to hear back?"
+
+**Friendly transformation:**
+> "Hey! Just wanted to check in on that email I sent a few days ago. No rush,
+> but let me know when you get a chance!"
+
+### Interaction patterns
+
+- Tone adjustment available from:
+  - Item detail view (prominent button)
+  - Long-press context menu
+  - Swipe action in Capture view
+- Preview state shows both original and transformed (can toggle)
+- Can dismiss transformation and return to original
+- Copy action includes success haptic and toast
+- Share action opens system share sheet with transformed text
+- Undo available for 30 seconds after applying transformation to item
+
+### Accessibility
+
+- VoiceOver describes tone options with full explanations
+- Haptic feedback for tone selection
+- Sufficient contrast for preview vs original text
+- Large touch targets for action buttons
+- Keyboard navigation for all tone controls
+
+---
+
+## 13. Risks & mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Transformations feel inauthentic or robotic | H | Preserve user's core meaning; allow editing; extensive testing with diverse inputs |
+| Users over-rely on feature and lose their own voice | M | Encourage reviewing and editing; don't auto-send; maintain original text visible |
+| On-device AI quality insufficient for nuanced tone shifts | H | Test extensively; fallback to cloud AI as opt-in; support manual editing |
+| Privacy concerns about processing personal messages | H | Clear on-device messaging; explicit opt-in for cloud; no retention |
+| Feature adds friction to quick communication | M | Make entirely optional; fast processing (<3s); preset shortcuts |
+| Tone suggestions feel judgmental about original text | M | Careful UI/messaging; never show "before/after" framing; emphasize choice |
+| Users don't understand when to use which tone | M | Provide clear tone descriptions with example use cases; suggest based on context |
+
+---
+
+## 14. Implementation tracking
+
+### Dependencies
+
+- On-device language model for style transfer
+- Tone parameter configuration system
+- Preset storage and retrieval in SwiftData
+- Share/copy workflow integration
+- Pattern matching for preset suggestions
+
+### Related features
+
+- Complements capture workflow
+- Could integrate with future messaging/email features
+- May inform organization categorization (formal items → work list)
+
+### Complexity estimate
+
+- **High complexity** due to nuanced AI tone transformation requirements
+- Estimated 3-4 week implementation for MVP
+- Additional 2 weeks for preset system and multi-tone preview
+
+### Testing requirements
+
+- Tone transformation quality testing with diverse messages
+- Preservation of meaning while changing tone verification
+- Edge case testing (very short messages, emoji-heavy, already formal)
+- Privacy testing for on-device processing
+- Accessibility testing for all tone controls
+- User testing with autistic/ADHD focus group for tone anxiety validation
+
+---
+
+## 15. Open decisions (tracked)
+
+| Decision | Owner | Status | Notes |
+| --- | --- | --- | --- |
+| Should we support tone blending (e.g., "formal + friendly")? | Product | Open | More flexible but potentially confusing; need UI clarity |
+| Include emoji suggestion as part of tone transformation? | Product | Open | Could help friendliness but may feel juvenile to some users |
+| Show confidence scores for transformation quality? | Design | Open | Transparency vs adding complexity |
+| Support for multi-paragraph transformations? | Engineering | Open | Longer text requires different approach than short messages |
+| Integration with future email/messaging apps? | Product | Deferred | Deep integration could streamline but adds scope |
+| Should presets include recipient type (e.g., "For professors")? | Product | Open | Helpful but risks overfitting to specific people |
+
+---
+
+## 16. Revision history
+
+| Version | Date | Notes |
+| --- | --- | --- |
+| 1.0 | 2026-01-24 | Initial draft based on Goblin Tools gap analysis |

--- a/docs/prds/prd-0011-executive-function-prompts.md
+++ b/docs/prds/prd-0011-executive-function-prompts.md
@@ -1,0 +1,462 @@
+---
+id: prd-0011-executive-function-prompts
+type: product-requirements
+status: draft
+owners:
+  - Offload
+applies_to:
+  - product
+last_updated: 2026-01-24
+related:
+  - adr-0003-adhd-focused-ux-ui-guardrails
+  - prd-0001-product-requirements
+  - prd-0007-smart-task-breakdown
+structure_notes:
+  - "Section order: 1. Product overview; 2. Problem statement; 3. Product goals; 4. Non-goals (explicit); 5. Target audience; 6. Success metrics; 7. Core user flows; 8. Functional requirements; 9. Pricing & limits; 10. AI & backend requirements; 11. Data model; 12. UX & tone requirements; 13. Risks & mitigations; 14. Implementation tracking; 15. Open decisions; 16. Revision history."
+---
+
+# Offload — Executive Function Prompts PRD
+
+**Version:** 1.0
+**Date:** 2026-01-24
+**Status:** Draft
+**Owner:** Offload
+
+**Related ADRs:**
+
+- [adr-0003: ADHD-Focused UX/UI Guardrails](../adrs/adr-0003-adhd-focused-ux-ui-guardrails.md)
+- [prd-0001: V1 Product Requirements](prd-0001-product-requirements.md)
+
+**Related PRDs:**
+
+- [prd-0007: Smart Task Breakdown](prd-0007-smart-task-breakdown.md)
+
+---
+
+## 1. Product overview
+
+Executive Function Prompts provides contextual guidance when users feel stuck,
+overwhelmed, or don't know how to proceed with a task. Instead of generic
+productivity advice, this feature asks clarifying questions and offers
+personalized micro-strategies based on the specific challenge the user is
+facing (task initiation, decision paralysis, time blindness, etc.).
+
+**Key differentiator from Goblin Tools:**
+
+- Addresses the "general questions about how to exist" gap identified by users
+- Context-aware guidance based on user's current state and task
+- Interactive dialogue, not just one-shot answers
+- Learns from user's successful strategies over time
+- Integrated with Offload's task and capture data for personalized help
+
+---
+
+## 2. Problem statement
+
+People with executive dysfunction experience recurring challenges that generic
+productivity tools don't address: "I don't know where to start," "This feels
+overwhelming," "I can't figure out how long this will take," "I'm stuck and
+can't make myself do this." These are executive function challenges, not
+motivation issues, and they benefit from specific prompting and scaffolding.
+
+**Core user pain:**
+> "I'm staring at 'Clean the apartment' and I just... can't. I know what needs
+> doing but my brain won't let me start. I need someone to just tell me the
+> literal first step, like 'put on your shoes and grab a trash bag.'"
+
+**Gap in existing tools (Goblin Tools):**
+
+- Tools focus on task decomposition but not on the emotional/cognitive blocks
+- No support for the "I don't even know what to ask for help with" feeling
+- No guided prompting through executive function challenges
+- Users noted wanting "specific questions on how to exist" answered
+
+---
+
+## 3. Product goals
+
+- Provide immediate, actionable guidance when users feel stuck
+- Detect common executive function challenges (initiation, overwhelm, time blindness)
+- Ask clarifying questions to understand the specific block
+- Offer micro-strategies and scaffolding tailored to the challenge
+- Learn which strategies work for the user over time
+- Reduce the activation energy required to start tasks
+- Normalize executive dysfunction without pathologizing
+- Maintain encouraging, non-judgmental tone
+
+---
+
+## 4. Non-goals (explicit)
+
+- No therapy or mental health diagnosis
+- No motivational platitudes ("You can do it!")
+- No rigid productivity methodologies (Pomodoro unless user requests)
+- No shame or judgment about struggles
+- No assumption of neurotypical executive function
+- No forced solutions (always offer options)
+
+---
+
+## 5. Target audience
+
+- People with ADHD experiencing task initiation difficulty
+- Those with executive dysfunction from any cause
+- Users who know what to do but can't start
+- People who feel overwhelmed by decision-making
+- Those who struggle with time estimation and planning
+- Anyone who experiences analysis paralysis
+
+---
+
+## 6. Success metrics (30-day post-launch)
+
+| Metric ID | Metric | Baseline | Target | Measurement |
+| --- | --- | --- | --- | --- |
+| M-1100 | % of users who use prompts feature | TBD | ≥30% | Analytics events |
+| M-1101 | % of prompted tasks that get started within 1 hour | TBD | ≥55% | Task initiation tracking |
+| M-1102 | User satisfaction with prompt helpfulness | TBD | ≥4.5/5 | In-app survey |
+| M-1103 | Average prompt interactions per session | TBD | 2-4 | Interaction depth |
+| M-1104 | % of users who report reduced task avoidance | TBD | ≥40% | User self-report |
+| M-1105 | Strategy reuse rate (using same strategy again) | TBD | ≥35% | Strategy tracking |
+
+---
+
+## 7. Core user flows
+
+### 7.1 "I don't know where to start"
+
+1. User has task "Clean the apartment" and feels stuck
+2. User taps "Help me start" action
+3. System asks: "What's making this hard right now?"
+   - It feels too big
+   - I don't have enough time
+   - I don't know what order to do things
+   - I just can't make myself do it
+   - Something else
+4. User selects "It feels too big"
+5. System offers micro-strategy:
+   > "Let's shrink it. What's one tiny visible thing you could do right now—
+   > something that takes less than 2 minutes? Maybe just clearing one surface
+   > or picking up trash from one room?"
+6. User captures micro-task: "Clear coffee table"
+7. System: "Perfect. Just that one thing. You can decide what's next after."
+8. User completes micro-task and momentum builds
+
+### 7.2 "I'm overwhelmed by everything"
+
+1. User has 15 uncompleted captures and feels paralyzed
+2. User taps "I'm overwhelmed" from Capture view
+3. System asks: "What would help right now?"
+   - Pick just one thing for me
+   - Hide everything else temporarily
+   - Help me sort by what's actually urgent
+   - I don't know
+4. User selects "Pick just one thing for me"
+5. System analyzes captures and suggests:
+   > "Based on your patterns, start with 'Call pharmacy for refill'—it's
+   > quick, important, and you usually feel relief after handling health stuff."
+6. User can accept suggestion or ask for different recommendation
+7. Other captures temporarily hidden until task complete
+
+### 7.3 "How long will this actually take?"
+
+1. User has task "Prepare presentation" with no time sense
+2. User taps "Help me estimate time"
+3. System asks clarifying questions:
+   - Have you done this before?
+   - How complex is this presentation?
+   - Are you starting from scratch or using a template?
+4. User answers questions
+5. System provides range estimate with buffer:
+   > "Based on similar tasks you've done, probably 2-3 hours. But build in an
+   > extra hour for unexpected formatting issues—you mentioned those happen a lot."
+6. System suggests time-boxing strategy if user interested
+7. User can save estimate to task
+
+### 7.4 "I can't decide what to do"
+
+1. User has captured multiple competing priorities
+2. User taps "Help me decide" from selection
+3. System asks: "What matters most today?"
+   - Get something done that's been bothering me
+   - Handle the most urgent thing
+   - Build momentum with something easy
+   - Work on what I have energy for right now
+4. User selects "Build momentum with something easy"
+5. System filters and suggests 2-3 easy wins
+6. User picks one and starts
+
+### 7.5 Learning from successful strategies
+
+1. User uses "Help me start" and completes micro-task successfully
+2. System notices completion and asks:
+   > "You started by just clearing the coffee table. Did that help you keep going?"
+3. User confirms yes
+4. System saves strategy: "Start with visible micro-task" for cleaning tasks
+5. Next time user faces similar task, system proactively suggests:
+   > "Last time you cleaned, starting with one small visible thing helped. Want
+   > to try that again?"
+
+---
+
+## 8. Functional requirements
+
+| Req ID | Requirement | Priority | User Story |
+| --- | --- | --- | --- |
+| FR-1100 | Provide "Help me start" action for tasks | Must | US-1100 |
+| FR-1101 | Detect common executive function challenges (initiation, overwhelm, time, decision) | Must | US-1101 |
+| FR-1102 | Ask clarifying questions to understand specific block | Must | US-1102 |
+| FR-1103 | Offer personalized micro-strategies based on challenge type | Must | US-1103 |
+| FR-1104 | Support "I'm overwhelmed" mode to simplify view | Must | US-1104 |
+| FR-1105 | Provide time estimation help with contextual questions | Should | US-1105 |
+| FR-1106 | Track which strategies lead to task completion | Should | US-1106 |
+| FR-1107 | Learn and suggest previously successful strategies | Should | US-1107 |
+| FR-1108 | Offer decision support for competing priorities | Should | US-1108 |
+| FR-1109 | Allow user to save favorite strategies | Could | US-1109 |
+| FR-1110 | Provide "unstuck" prompts during long idle periods | Could | US-1110 |
+| FR-1111 | Share strategies with other users | Won't | - |
+| FR-1112 | Push notifications for prompts | Won't | - |
+
+---
+
+## 9. Pricing & limits (hybrid model)
+
+### Free tier
+
+- 10 prompt sessions per month
+- Basic challenge types (initiation, overwhelm)
+- Manual strategy invocation
+
+### Paid tier
+
+- Unlimited prompt sessions
+- Advanced challenge types (decision, time, energy)
+- Automatic strategy learning and suggestions
+- Historical strategy analytics
+- Priority response times
+
+**Rationale:** Executive function support is core to the neurodivergent value
+proposition. Free tier provides essential scaffolding; paid tier for users who
+rely heavily on prompting support.
+
+---
+
+## 10. AI & backend requirements
+
+### On-device AI (Phase 1 - Offline)
+
+- Natural language understanding for clarifying questions
+- Context analysis to detect challenge type from task and user state
+- Strategy recommendation based on rules and learned patterns
+- Personalization from tracked completions
+- No internet required for core functionality
+
+### Backend AI (Phase 2+ - Optional)
+
+- More sophisticated strategy recommendations from LLM
+- Cross-user pattern insights (anonymized)
+- Advanced time estimation using project decomposition
+- Natural conversation flow improvements
+
+### Privacy requirements
+
+- All prompt interactions happen on-device by default
+- Task content never sent to cloud without explicit opt-in
+- Strategy learning stored locally in SwiftData
+- No tracking of emotional states or mental health data
+
+---
+
+## 11. Data model
+
+### New models
+
+#### PromptSession
+
+- `id: UUID` - Unique identifier
+- `taskId: UUID?` - Related task if applicable
+- `challengeType: ChallengeType` - What user struggled with
+- `clarifyingQuestions: [QuestionAnswer]` - Dialogue history
+- `strategySuggested: String` - What guidance was provided
+- `strategyAccepted: Bool` - Whether user followed suggestion
+- `outcomeSuccess: Bool?` - If task was completed after prompt
+- `completionDelay: TimeInterval?` - Time from prompt to completion
+- `userFeedback: PromptFeedback?` - User rating of helpfulness
+- `createdAt: Date` - When session started
+
+#### ChallengeType (Enum)
+
+- `initiation` - Can't start task
+- `overwhelm` - Too many things, paralyzed
+- `timeBlindness` - Can't estimate duration
+- `decision` - Can't choose what to do
+- `energy` - Low capacity, need right-sized task
+- `order` - Don't know sequence of steps
+- `unknown` - User isn't sure what the block is
+
+#### QuestionAnswer (Codable)
+
+- `question: String` - System question
+- `answer: String` - User response
+- `timestamp: Date` - When answered
+
+#### PromptFeedback (Codable)
+
+- `helpful: Bool` - Did the prompt help?
+- `rating: Int?` - 1-5 optional rating
+- `comment: String?` - Optional user notes
+
+#### SuccessfulStrategy
+
+- `id: UUID` - Unique identifier
+- `challengeType: ChallengeType` - What it helps with
+- `strategyDescription: String` - What to do
+- `taskPattern: String?` - Type of task this works for
+- `timesUsed: Int` - How often applied
+- `successRate: Float` - % of times it led to completion
+- `lastUsed: Date?` - Most recent application
+- `createdAt: Date` - When first identified
+
+### Existing model changes
+
+#### Item
+
+- `promptSessionIds: [UUID]?` - Links to PromptSession records
+- No required changes, sessions tracked separately
+
+---
+
+## 12. UX & tone requirements
+
+### Visual design
+
+- Prompt entry point as calm, inviting button (not emergency-feeling)
+- Challenge type selector uses cards with clear icons and descriptions
+- Conversational UI for clarifying questions (chat-like bubbles)
+- Strategy suggestions in highlighted, easy-to-read cards
+- Progress indicator for multi-step prompts
+- Success confirmation after task completion tied to prompt
+
+### Tone & messaging
+
+- **Normalizing, not pathologizing:** "This is a really common challenge" vs "You have a problem"
+- **Concrete, not abstract:** "Clear one surface" vs "Start small"
+- **Collaborative:** "Let's figure this out together" not "Here's what you should do"
+- **Non-judgmental:** Never imply task avoidance is laziness or lack of willpower
+- **Empowering:** Emphasize user's agency and past successes
+- **Patient:** No rush, no pressure, user can exit anytime
+
+### Example prompt dialogues
+
+**Initiation challenge:**
+> **System:** "What's making this hard to start right now?"
+> **User:** "It feels too big"
+> **System:** "That makes sense. What if we found just the tiniest first step—
+> something you could do in under 2 minutes? What's one small visible thing?"
+> **User:** "I could pick up the mugs from my desk"
+> **System:** "Perfect. Just that. You can figure out what's next after those
+> mugs are in the sink."
+
+**Overwhelm challenge:**
+> **System:** "You have 12 things in your inbox and it looks like you're stuck.
+> Want me to help you focus on just one thing?"
+> **User:** "Yes please"
+> **System:** "What would help most right now—tackling something urgent, or
+> getting an easy win for momentum?"
+> **User:** "Easy win"
+> **System:** "Got it. How about 'Order new phone charger'? You can do that in
+> 2 minutes and cross it off. The rest can wait."
+
+**Time estimation challenge:**
+> **System:** "You're not sure how long 'Tax prep' will take. Have you gathered
+> your documents yet?"
+> **User:** "No"
+> **System:** "Okay, so there's gathering docs, then the actual forms. Doc
+> gathering usually takes longer than people think—maybe budget 1-2 hours for
+> that first. Then the forms might be another hour. Sound about right?"
+> **User:** "Yeah that feels better than 'do taxes' with no time"
+
+### Interaction patterns
+
+- Prompt sessions can be paused and resumed
+- User can back up to previous question
+- Can exit prompt session anytime without penalty
+- Successful strategies saved automatically with opt-out
+- Strategy suggestions appear proactively but are dismissible
+- Celebration after completion: "You did it! That strategy worked."
+
+### Accessibility
+
+- VoiceOver reads full prompt dialogue with appropriate pausing
+- Haptic feedback for successful strategy identification
+- High contrast for clarifying questions
+- Large touch targets for all response options
+- Keyboard navigation through prompt flow
+
+---
+
+## 13. Risks & mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Prompts feel like therapy/diagnosis, making users uncomfortable | H | Clear messaging this is productivity scaffolding, not mental health care |
+| Users feel judged by questions about what's blocking them | H | Extensive tone testing with neurodivergent users; normalize struggles |
+| Strategies feel too simplistic or patronizing | M | Concrete and specific, not generic advice; acknowledge user's intelligence |
+| Feature increases cognitive load instead of reducing it | H | Simple interaction flow; easy exit; optional feature |
+| Privacy concerns about tracking struggles and blocks | M | Clear on-device processing; no mental health data collection |
+| Users become dependent on prompts and can't self-advocate | L | Teach strategies, not just provide answers; gradual independence |
+| Prompt timing feels intrusive or nagging | M | User-initiated only; no automatic prompts without permission |
+
+---
+
+## 14. Implementation tracking
+
+### Dependencies
+
+- Prompt dialogue system with conversational flow
+- Strategy recommendation engine
+- Success tracking and learning system
+- Integration with task and capture views
+- User feedback collection
+
+### Related features
+
+- Complements Smart Task Breakdown (prd-0007)
+- May inform future coaching or onboarding features
+- Could integrate with future time estimation features
+
+### Complexity estimate
+
+- **Medium-high complexity** due to conversational AI and learning requirements
+- Estimated 3-4 week implementation for MVP
+- Additional 2 weeks for strategy learning and refinements
+
+### Testing requirements
+
+- Prompt dialogue quality testing with diverse challenges
+- Strategy effectiveness validation with real user tasks
+- Learning system accuracy for successful strategy identification
+- Tone and messaging testing with ADHD/autistic focus groups
+- Privacy testing for prompt session data
+- Accessibility testing for conversational UI
+
+---
+
+## 15. Open decisions (tracked)
+
+| Decision | Owner | Status | Notes |
+| --- | --- | --- | --- |
+| Should prompts be purely conversational or include visual guides? | Design | Open | Text may not be enough for some users; consider diagrams/videos |
+| Integrate with body doubling or accountability features? | Product | Deferred | Could be powerful but adds scope |
+| Allow users to create custom prompt flows? | Product | Open | Power feature but risks complexity |
+| Surface when user is stuck based on idle time? | Product | Open | Could be helpful vs intrusive; needs careful testing |
+| Include library of common neurodivergent challenges and strategies? | Product | Open | Educational value but risks feeling prescriptive |
+| Partner with ADHD coaches for strategy content? | Business | Deferred | Could improve quality but adds dependency |
+
+---
+
+## 16. Revision history
+
+| Version | Date | Notes |
+| --- | --- | --- |
+| 1.0 | 2026-01-24 | Initial draft based on Goblin Tools gap analysis |

--- a/docs/prds/prd-0012-decision-fatigue-reducer.md
+++ b/docs/prds/prd-0012-decision-fatigue-reducer.md
@@ -1,0 +1,449 @@
+---
+id: prd-0012-decision-fatigue-reducer
+type: product-requirements
+status: draft
+owners:
+  - Offload
+applies_to:
+  - product
+last_updated: 2026-01-24
+related:
+  - adr-0003-adhd-focused-ux-ui-guardrails
+  - prd-0001-product-requirements
+  - prd-0011-executive-function-prompts
+structure_notes:
+  - "Section order: 1. Product overview; 2. Problem statement; 3. Product goals; 4. Non-goals (explicit); 5. Target audience; 6. Success metrics; 7. Core user flows; 8. Functional requirements; 9. Pricing & limits; 10. AI & backend requirements; 11. Data model; 12. UX & tone requirements; 13. Risks & mitigations; 14. Implementation tracking; 15. Open decisions; 16. Revision history."
+---
+
+# Offload — Decision Fatigue Reducer PRD
+
+**Version:** 1.0
+**Date:** 2026-01-24
+**Status:** Draft
+**Owner:** Offload
+
+**Related ADRs:**
+
+- [adr-0003: ADHD-Focused UX/UI Guardrails](../adrs/adr-0003-adhd-focused-ux-ui-guardrails.md)
+- [prd-0001: V1 Product Requirements](prd-0001-product-requirements.md)
+
+**Related PRDs:**
+
+- [prd-0011: Executive Function Prompts](prd-0011-executive-function-prompts.md)
+
+---
+
+## 1. Product overview
+
+Decision Fatigue Reducer helps users break through analysis paralysis when
+facing multiple options or competing priorities. Instead of presenting all
+choices equally, this feature asks clarifying questions to understand what
+matters most, then recommends 2-3 "good enough" options with brief rationale.
+The goal is to reduce decision-making from overwhelming to manageable,
+following Offload's "fewer options over many" principle.
+
+**Key differentiator from Goblin Tools' Consultant:**
+
+- Integrated with user's existing captures and priorities
+- Learns from user's stated values and past decisions
+- Emphasizes "good enough" over perfect choice
+- Reduces options to 2-3 instead of analyzing all
+- Context-aware based on user's energy and capacity
+
+---
+
+## 2. Problem statement
+
+People with ADHD and executive dysfunction often experience decision paralysis,
+especially when every option seems equally valid or when the decision feels
+high-stakes. Traditional decision tools present frameworks or pros/cons lists
+that require more cognitive work. What users need is someone to just help them
+pick something reasonable and move forward.
+
+**Core user pain:**
+> "I have 8 things I could work on and I've spent 20 minutes trying to decide
+> which one. Now I'm exhausted and haven't done any of them. I just need
+> someone to tell me 'do this one' so I can stop thinking about it."
+
+**Gap in existing tools (Goblin Tools):**
+
+- Consultant is standalone, not integrated with task management
+- Provides analysis but doesn't reduce options
+- Doesn't learn from user's priorities over time
+- No support for the "just pick for me" feeling
+
+---
+
+## 3. Product goals
+
+- Reduce cognitive load of choosing between options
+- Provide "good enough" recommendations, not perfect solutions
+- Limit choices to 2-3 options (never present all options)
+- Ask minimal clarifying questions (1-2 max)
+- Learn from user's stated priorities and past decisions
+- Support both task prioritization and life decisions
+- Emphasize that any choice is better than no choice
+- Maintain encouraging, pressure-free tone
+
+---
+
+## 4. Non-goals (explicit)
+
+- No complex decision frameworks or matrices
+- No lengthy pros/cons analysis
+- No assumption that "optimal" decisions exist
+- No judgment about decision difficulty
+- No life coaching or values clarification exercises
+- No tracking of "right" vs "wrong" decisions
+
+---
+
+## 5. Target audience
+
+- People with ADHD who experience analysis paralysis
+- Users overwhelmed by competing priorities
+- Those who spend excessive time making decisions
+- People who seek external validation for choices
+- Anyone experiencing decision fatigue from mental overload
+
+---
+
+## 6. Success metrics (30-day post-launch)
+
+| Metric ID | Metric | Baseline | Target | Measurement |
+| --- | --- | --- | --- | --- |
+| M-1200 | % of users who use decision support | TBD | ≥25% | Analytics events |
+| M-1201 | % of decision sessions that result in task start | TBD | ≥65% | Task initiation tracking |
+| M-1202 | Average time from decision request to selection | TBD | <2 min | Session duration |
+| M-1203 | User satisfaction with recommendations | TBD | ≥4.2/5 | In-app survey |
+| M-1204 | % of users who report reduced decision anxiety | TBD | ≥45% | User self-report |
+| M-1205 | Recommendation acceptance rate (chose suggested option) | TBD | ≥60% | Selection tracking |
+
+---
+
+## 7. Core user flows
+
+### 7.1 "Help me choose what to work on"
+
+1. User has 8 items in Capture view, feels stuck
+2. User selects multiple items and taps "Help me decide"
+3. System asks one clarifying question: "What matters most right now?"
+   - Get something done that's been nagging me
+   - Make progress on something important
+   - Build momentum with something easy
+   - Work on whatever I have energy for
+4. User selects "Build momentum with something easy"
+5. System analyzes selected items and recommends 2 options:
+   > **Option 1: Order new phone charger** (5 min, you've been putting this
+   > off, easy win)
+   >
+   > **Option 2: Text Sarah about lunch** (2 min, quick and friendly)
+6. User picks Option 1, other items remain for later
+7. System: "Great choice. The rest can wait—just focus on this."
+
+### 7.2 "Just pick for me"
+
+1. User has competing priorities and taps "Just pick for me"
+2. System skips clarifying questions and immediately recommends:
+   > "Start with 'Call pharmacy.' It's time-sensitive, you've done this before,
+   > and it'll feel good to have it done."
+3. User can accept, reject for different suggestion, or cancel
+4. If accepted, item is highlighted and others temporarily dimmed
+
+### 7.3 "Which approach should I take?"
+
+1. User has captured multiple ways to approach a problem:
+   - "Apply for new job"
+   - "Ask for raise at current job"
+   - "Look for freelance work"
+2. User selects all three and taps "Help me decide"
+3. System asks: "What feels most important?"
+   - Stability and security
+   - Growth and challenge
+   - Flexibility and control
+4. User selects "Stability and security"
+5. System recommends:
+   > **Recommended: Ask for raise at current job**
+   > Keeps your current stability while improving income. Less risky than job
+   > change. You can always explore other options later if this doesn't work.
+   >
+   > **Alternative: Look for freelance work**
+   > Gives you flexibility to test waters while keeping current job. Lower
+   > risk than full job change.
+6. User reviews and picks one approach to pursue
+
+### 7.4 Learning from decisions
+
+1. User gets recommendation based on "build momentum" priority
+2. User rejects it and asks for different recommendation
+3. User selects the alternative suggestion
+4. System notes: User prioritized differently than expected
+5. Next decision session, system adjusts weighting:
+   > "Last time you chose the slightly harder task. Want me to suggest based
+   > on that pattern, or stick with easy wins?"
+
+### 7.5 "Break the tie between two options"
+
+1. User has narrowed down to 2 competing options but still can't decide
+2. User selects both and taps "Help me pick"
+3. System analyzes context (time of day, recent completions, stated priorities)
+4. System flips a weighted coin and recommends:
+   > "Go with Option A. Here's why: you tend to do better with tasks like this
+   > in the afternoon, and you just finished something similar successfully."
+5. User accepts and proceeds, relieved to have decision made
+
+---
+
+## 8. Functional requirements
+
+| Req ID | Requirement | Priority | User Story |
+| --- | --- | --- | --- |
+| FR-1200 | Provide decision support for selected items | Must | US-1200 |
+| FR-1201 | Ask max 1-2 clarifying questions before recommending | Must | US-1201 |
+| FR-1202 | Recommend 2-3 options maximum, never all choices | Must | US-1202 |
+| FR-1203 | Provide brief rationale for recommendations | Must | US-1203 |
+| FR-1204 | Support "just pick for me" mode with zero questions | Must | US-1204 |
+| FR-1205 | Learn from user's priority selections over time | Should | US-1205 |
+| FR-1206 | Track which recommendations user accepts vs rejects | Should | US-1206 |
+| FR-1207 | Adjust weighting based on user's decision patterns | Should | US-1207 |
+| FR-1208 | Support tie-breaking between 2 final options | Should | US-1208 |
+| FR-1209 | Temporarily hide non-selected items to reduce distraction | Could | US-1209 |
+| FR-1210 | Show decision history and patterns | Could | US-1210 |
+| FR-1211 | Multi-criteria decision analysis | Won't | - |
+| FR-1212 | Long-term decision tracking and outcomes | Won't | - |
+
+---
+
+## 9. Pricing & limits (hybrid model)
+
+### Free tier
+
+- 10 decision sessions per month
+- Basic recommendations (2 options)
+- Single clarifying question
+
+### Paid tier
+
+- Unlimited decision sessions
+- Advanced recommendations (context-aware, pattern-learning)
+- "Just pick for me" instant recommendations
+- Decision history and pattern insights
+- Custom priority weighting
+
+**Rationale:** Decision support is valuable for critical moments of paralysis.
+Free tier provides essential help; paid tier for users who rely on decision
+scaffolding regularly.
+
+---
+
+## 10. AI & backend requirements
+
+### On-device AI (Phase 1 - Offline)
+
+- Priority detection from user's selections and stated preferences
+- Basic recommendation logic based on task attributes
+- Pattern recognition for repeated decision types
+- No internet required for core functionality
+
+### Backend AI (Phase 2+ - Optional)
+
+- More sophisticated priority understanding from LLM
+- Cross-user decision pattern insights (anonymized)
+- Natural language processing for user's priorities
+- Advanced context awareness (time, energy, history)
+
+### Privacy requirements
+
+- All decision processing happens on-device by default
+- User priorities stored locally in SwiftData
+- No sharing of decision content or user choices
+- If cloud AI used, decisions encrypted and not retained
+
+---
+
+## 11. Data model
+
+### New models
+
+#### DecisionSession
+
+- `id: UUID` - Unique identifier
+- `itemIds: [UUID]` - Items being decided between
+- `clarifyingQuestion: String?` - Question asked (if any)
+- `userPriority: DecisionPriority?` - User's stated priority
+- `recommendedOptions: [RecommendedOption]` - What was suggested
+- `userSelection: UUID?` - Which option user chose
+- `selectionWasRecommended: Bool` - Did user pick suggested option?
+- `skipQuestions: Bool` - "Just pick for me" mode
+- `sessionDuration: TimeInterval` - Time to make decision
+- `createdAt: Date` - When session started
+
+#### DecisionPriority (Enum)
+
+- `naggerRelief` - Get rid of something bothering me
+- `importantProgress` - Make progress on important goal
+- `easyMomentum` - Build momentum with easy task
+- `energyMatched` - Whatever I have energy for
+- `timeSensitive` - Handle urgent/time-sensitive item
+- `curiosity` - Work on what interests me right now
+
+#### RecommendedOption (Codable)
+
+- `itemId: UUID` - Which item
+- `rank: Int` - 1st, 2nd, or 3rd recommendation
+- `rationale: String` - Why this was suggested
+- `confidence: Float` - System confidence in suggestion
+
+#### DecisionPattern
+
+- `id: UUID` - Unique identifier
+- `priorityType: DecisionPriority` - What user typically values
+- `contextPatterns: [String: Any]` - When this priority applies
+- `successRate: Float` - % of time this leads to task completion
+- `timesObserved: Int` - How many decisions show this pattern
+- `lastObserved: Date` - Most recent observation
+
+### Existing model changes
+
+#### Item
+
+- `decisionSessionIds: [UUID]?` - Links to DecisionSession records
+- No required changes, sessions tracked separately
+
+---
+
+## 12. UX & tone requirements
+
+### Visual design
+
+- Decision entry point as clear action button when multiple items selected
+- Priority selector as large, easy-to-tap cards with icons
+- Recommendations shown as distinct cards with rank badges (1st, 2nd)
+- Rationale text in friendly, conversational style
+- "Just pick for me" as prominent alternative action
+- Non-selected items visually dimmed after decision
+- Celebration for making decision, not specific choice
+
+### Tone & messaging
+
+- **Normalizing decision difficulty:** "Choosing is hard—that's normal"
+- **Emphasizing good enough:** "Any of these is a good choice" not "Here's the best one"
+- **Relieving pressure:** "You can't make a wrong choice here"
+- **Acknowledging uncertainty:** "I'm making an educated guess based on..."
+- **Celebrating decision, not outcome:** "You made a choice! That's the hard part."
+- **No second-guessing:** Never ask "Are you sure?" after user picks
+
+### Example recommendation messages
+
+**For momentum-seeking user:**
+> **1st: Order new phone charger** (5 min)
+> This is super quick and you've been putting it off. Easy win to get you moving.
+>
+> **2nd: Text Sarah about lunch** (2 min)
+> Even faster, and you like connecting with friends. Another quick momentum builder.
+
+**For "just pick for me" mode:**
+> **Do this one: Call pharmacy**
+> It's time-sensitive, you've done this before, and it'll feel good to have it done.
+> The rest can wait.
+
+**For important progress priority:**
+> **1st: Outline presentation for Friday**
+> This is your most important deadline. Getting the outline done today means less
+> stress tomorrow.
+>
+> **2nd: Review contract for client**
+> Also important and time-sensitive, but the presentation feels more urgent.
+
+### Clarifying question examples
+
+- "What matters most right now?"
+- "What kind of energy do you have?"
+- "What would feel best to accomplish today?"
+- "Which of these has been nagging you the most?"
+
+### Interaction patterns
+
+- Decision flow is quick (max 3 taps: action → priority → select)
+- Can skip clarifying question with "Just pick for me" at any time
+- Can request different recommendation if first doesn't resonate
+- Non-selected items remain accessible, just visually de-emphasized
+- Undo available: "Changed your mind? Pick something else"
+- No penalty for rejecting recommendations
+
+### Accessibility
+
+- VoiceOver reads full rationale for each recommendation
+- Haptic feedback for recommendation selection
+- High contrast for recommended vs non-recommended items
+- Large touch targets for all priority and selection options
+- Keyboard navigation through decision flow
+
+---
+
+## 13. Risks & mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Recommendations feel arbitrary or unhelpful | H | Transparent rationale; learn from rejections; extensive testing |
+| Users second-guess AI recommendations, adding anxiety | M | Emphasize "good enough"; celebrate decision regardless of choice |
+| Feature becomes crutch, users can't decide without it | L | Frame as scaffolding, not replacement for judgment; gradual independence |
+| Priority questions feel like quiz, adding cognitive load | M | Limit to 1-2 questions max; "just pick for me" always available |
+| Privacy concerns about tracking decision patterns | M | Clear on-device processing; user controls pattern learning |
+| Recommendations too conservative or risk-averse | M | Include stretch options occasionally; learn from user's actual picks |
+| Users disagree with recommendation rationale | L | Allow feedback; adjust future recommendations; normalize different preferences |
+
+---
+
+## 14. Implementation tracking
+
+### Dependencies
+
+- Multi-select UI in Capture and Organize views
+- Priority understanding and recommendation logic
+- Pattern learning from decision history
+- Integration with item attributes and user context
+- User feedback collection
+
+### Related features
+
+- Complements Executive Function Prompts (prd-0011)
+- May inform future prioritization and planning features
+- Could integrate with recurring task patterns
+
+### Complexity estimate
+
+- **Medium complexity** for recommendation logic
+- **Low complexity** for basic UI
+- Estimated 2-3 week implementation for MVP
+- Additional 1-2 weeks for pattern learning and refinements
+
+### Testing requirements
+
+- Recommendation quality testing with diverse item sets
+- Priority detection accuracy validation
+- Pattern learning effectiveness over time
+- User satisfaction testing with decision-anxious users
+- Accessibility testing for all decision interactions
+- A/B testing of clarifying questions to minimize cognitive load
+
+---
+
+## 15. Open decisions (tracked)
+
+| Decision | Owner | Status | Notes |
+| --- | --- | --- | --- |
+| Should we show confidence scores for recommendations? | Design | Open | Transparency vs additional information to process |
+| Include "I'll come back to this" option to defer decision? | Product | Open | Could enable avoidance vs relieve pressure |
+| How many past decisions to use for pattern learning? | Engineering | Open | Balance between personalization and recency |
+| Support for non-task decisions (e.g., "what to eat")? | Product | Deferred | Interesting but scope expansion; defer to Phase 2 |
+| Show other users' anonymous decision patterns? | Product | Open | Could normalize choices vs add comparison pressure |
+| Integration with future calendar/scheduling features? | Product | Deferred | Decisions could inform time blocking |
+
+---
+
+## 16. Revision history
+
+| Version | Date | Notes |
+| --- | --- | --- |
+| 1.0 | 2026-01-24 | Initial draft based on Goblin Tools gap analysis |


### PR DESCRIPTION
## Summary
- add six PRDs for cognitive support features (smart task breakdown, brain dump compiler, recurring task intelligence, tone assistant, executive function prompts, decision fatigue reducer)
- format data model subheads to satisfy markdownlint

## Testing
- `markdownlint --fix docs/prds/prd-0007-smart-task-breakdown.md docs/prds/prd-0008-brain-dump-compiler.md docs/prds/prd-0009-recurring-task-intelligence.md docs/prds/prd-0010-tone-assistant.md docs/prds/prd-0011-executive-function-prompts.md docs/prds/prd-0012-decision-fatigue-reducer.md`
