### PR TITLE
chore(docs): archive completed plans and sync README statuses

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -64,15 +64,13 @@ proposed → accepted → in-progress → completed/archived
 
 - [Plan: Testing & Polish](./plan-testing-polish.md)
 - [Plan: Release Prep](./plan-release-prep.md)
+- [Plan: UX & Accessibility Audit Fixes](./plan-ux-accessibility-audit-fixes.md)
 
-### Accepted
+### Complete (Awaiting User Verification)
 
-- [Plan: Persistent Bottom Tab Bar](./plan-persistent-bottom-tab-bar.md)
 - [Plan: Convert Plans and Lists](./plan-convert-plans-lists.md)
 - [Plan: Drag and Drop Ordering](./plan-drag-drop-ordering.md)
 - [Plan: Item Search by Text or Tag](./plan-item-search-tags.md)
-- [Plan: Logging Implementation](./plan-logging-implementation.md)
-- [Plan: Context-Aware CI Pipeline](./plan-context-aware-ci-pipeline.md)
 
 ### Proposed (Pending Confirmations)
 
@@ -92,6 +90,9 @@ Archived plans have been moved to `_archived/`. See
 Notable archived plans include:
 
 - [Offload Roadmap](./_archived/plan-roadmap.md)
+- [Persistent Bottom Tab Bar](./_archived/plan-persistent-bottom-tab-bar.md)
+- [Logging Implementation](./_archived/plan-logging-implementation.md)
+- [Context-Aware CI Pipeline](./_archived/plan-context-aware-ci-pipeline.md)
 
 ## Template
 

--- a/docs/plans/_archived/README.md
+++ b/docs/plans/_archived/README.md
@@ -7,7 +7,7 @@ owners:
 applies_to:
   - plans
   - archived
-last_updated: 2026-01-25
+last_updated: 2026-02-09
 related:
   - plan-archived-brain-dump-model
   - plan-archived-consolidated-implementation-plan
@@ -21,6 +21,9 @@ related:
   - plan-archived-tag-relationship-refactor
   - plan-archived-view-decomposition
   - plan-roadmap
+  - plan-persistent-bottom-tab-bar
+  - plan-logging-implementation
+  - plan-context-aware-ci-pipeline
 depends_on: []
 supersedes: []
 accepted_by: null
@@ -66,6 +69,9 @@ Same authority as plans, but no longer active. Archived plans are historical rec
 - [Tag Relationship Refactor Plan](./plan-archived-tag-relationship-refactor.md)
 - [View Decomposition Plan](./plan-archived-view-decomposition.md)
 - [Offload Roadmap](./plan-roadmap.md)
+- [Persistent Bottom Tab Bar](./plan-persistent-bottom-tab-bar.md)
+- [Logging Implementation](./plan-logging-implementation.md)
+- [Context-Aware CI Pipeline](./plan-context-aware-ci-pipeline.md)
 
 ## Naming
 

--- a/docs/plans/_archived/plan-context-aware-ci-pipeline.md
+++ b/docs/plans/_archived/plan-context-aware-ci-pipeline.md
@@ -1,7 +1,7 @@
 ---
 id: plan-context-aware-ci-pipeline
 type: plan
-status: complete
+status: archived
 owners:
   - Will-Conklin
 applies_to:

--- a/docs/plans/_archived/plan-logging-implementation.md
+++ b/docs/plans/_archived/plan-logging-implementation.md
@@ -1,7 +1,7 @@
 ---
 id: plan-logging-implementation
 type: plan
-status: complete
+status: archived
 owners:
   - Will-Conklin
 applies_to:

--- a/docs/plans/_archived/plan-persistent-bottom-tab-bar.md
+++ b/docs/plans/_archived/plan-persistent-bottom-tab-bar.md
@@ -1,7 +1,7 @@
 ---
 id: plan-persistent-bottom-tab-bar
 type: plan
-status: complete
+status: archived
 owners:
   - Will-Conklin
 applies_to:

--- a/docs/plans/plan-ux-accessibility-audit-fixes.md
+++ b/docs/plans/plan-ux-accessibility-audit-fixes.md
@@ -1,7 +1,7 @@
 ---
 id: plan-ux-accessibility-audit-fixes
 type: plan
-status: proposed
+status: in-progress
 owners:
   - Will-Conklin
 applies_to:


### PR DESCRIPTION
## Summary

- Archive 3 user-verified plans to `_archived/`: persistent bottom tab bar, logging implementation, context-aware CI pipeline
- Restructure plans README to reflect actual statuses — replace stale "Accepted" section with "Complete (Awaiting User Verification)" for 3 plans pending device verification
- Add UX & Accessibility Audit Fixes plan to "In Progress" and fix its frontmatter status from `proposed` to `in-progress`
- Update `_archived/README.md` with newly archived plan references

## Test plan

- [x] Verify all plan file links in `docs/plans/README.md` resolve correctly
- [x] Verify all plan file links in `docs/plans/_archived/README.md` resolve correctly
- [x] Confirm archived plan files exist in `docs/plans/_archived/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)