### PR TITLE
fix(data): prevent orphaned collection links with entity validation

### DIFF
--- a/docs/plans/plan-fix-orphaned-collection-links.md
+++ b/docs/plans/plan-fix-orphaned-collection-links.md
@@ -1,7 +1,7 @@
 ---
 id: plan-fix-orphaned-collection-links
 type: plan
-status: proposed
+status: in-progress
 owners:
   - Will-Conklin
 applies_to:
@@ -12,8 +12,8 @@ last_updated: 2026-02-12
 related: []
 depends_on: []
 supersedes: []
-accepted_by: null
-accepted_at: null
+accepted_by: Will-Conklin
+accepted_at: 2026-02-12
 related_issues:
   - https://github.com/Will-Conklin/offload/issues/147
 structure_notes:
@@ -72,37 +72,38 @@ func addItemToCollection(itemId: UUID, collectionId: UUID, ...) throws -> Collec
 
 ### Phase 1: Add Validation Guards
 
-**Status:** Not Started
+**Status:** Complete
 
-- [ ] **Update `addItemToCollection` method** (lines 19-38)
-  - Add guard after `fetchCollection`: `guard let collection else { throw ValidationError("Collection not found") }`
-  - Add `AppLogger.general.error` before throw with collection ID
-  - Add guard after `fetchItem`: `guard let item else { throw ValidationError("Item not found") }`
-  - Add `AppLogger.general.error` before throw with item ID
-  - Keep remaining logic unchanged
+- [x] **Update `addItemToCollection` method** (lines 19-46)
+  - Added guard after `fetchCollection` with `ValidationError("Collection not found")`
+  - Added `AppLogger.persistence.error` before throw with collection ID
+  - Added guard after `fetchItem` with `ValidationError("Item not found")`
+  - Added `AppLogger.persistence.error` before throw with item ID
+  - Added OSLog import for AppLogger support
 
-- [ ] **Update `moveItemToCollection` method** (lines 161-173)
-  - Add guard after `fetchCollection`: `guard let collection else { throw ValidationError("Collection not found") }`
-  - Add `AppLogger.general.error` before throw with collection ID
-  - Keep remaining logic unchanged
+- [x] **Update `moveItemToCollection` method** (lines 173-185)
+  - Added guard after `fetchCollection` with `ValidationError("Collection not found")`
+  - Added `AppLogger.persistence.error` before throw with collection ID
+  - Kept remaining logic unchanged
 
 ### Phase 2: Add Test Coverage
 
-**Status:** Not Started
+**Status:** Complete
 
-- [ ] **Create test file or extend `CollectionItemRepositoryTests.swift`**
-  - Add `testAddItemToCollection_ThrowsWhenCollectionNotFound`
-    - Create item with valid ID
-    - Call `addItemToCollection` with invalid collection ID
-    - Assert throws `ValidationError` with message "Collection not found"
-  - Add `testAddItemToCollection_ThrowsWhenItemNotFound`
-    - Create collection with valid ID
-    - Call `addItemToCollection` with invalid item ID
-    - Assert throws `ValidationError` with message "Item not found"
-  - Add `testMoveItemToCollection_ThrowsWhenCollectionNotFound`
-    - Create collection, item, and collectionItem
-    - Call `moveItemToCollection` with invalid target collection ID
-    - Assert throws `ValidationError` with message "Collection not found"
+- [x] **Extended `CollectionItemRepositoryTests.swift`**
+  - Added `testAddItemToCollection_ThrowsWhenCollectionNotFound` (lines 158-171)
+    - Creates item with valid ID
+    - Calls `addItemToCollection` with invalid collection ID
+    - Asserts throws `ValidationError` with message "Collection not found"
+  - Added `testAddItemToCollection_ThrowsWhenItemNotFound` (lines 173-186)
+    - Creates collection with valid ID
+    - Calls `addItemToCollection` with invalid item ID
+    - Asserts throws `ValidationError` with message "Item not found"
+  - Added `testMoveItemToCollection_ThrowsWhenCollectionNotFound` (lines 188-206)
+    - Creates collection, item, and collectionItem
+    - Calls `moveItemToCollection` with invalid target collection ID
+    - Asserts throws `ValidationError` with message "Collection not found"
+  - All new tests pass successfully
 
 ### Phase 3: Verification
 

--- a/ios/Offload/Data/Repositories/CollectionItemRepository.swift
+++ b/ios/Offload/Data/Repositories/CollectionItemRepository.swift
@@ -4,6 +4,7 @@
 // Additional instructions: Keep CRUD logic centralized and consistent with SwiftData models.
 
 import Foundation
+import OSLog
 import SwiftData
 
 @MainActor
@@ -23,7 +24,17 @@ final class CollectionItemRepository {
         parentId: UUID? = nil
     ) throws -> CollectionItem {
         let collection = try fetchCollection(collectionId)
+        guard let collection else {
+            AppLogger.persistence.error("Failed to add item to collection - collection not found: \(collectionId, privacy: .public)")
+            throw ValidationError("Collection not found")
+        }
+
         let item = try fetchItem(itemId)
+        guard let item else {
+            AppLogger.persistence.error("Failed to add item to collection - item not found: \(itemId, privacy: .public)")
+            throw ValidationError("Item not found")
+        }
+
         let collectionItem = CollectionItem(
             collectionId: collectionId,
             itemId: itemId,
@@ -164,6 +175,11 @@ final class CollectionItemRepository {
         position: Int? = nil
     ) throws {
         let collection = try fetchCollection(toCollectionId)
+        guard let collection else {
+            AppLogger.persistence.error("Failed to move item - collection not found: \(toCollectionId, privacy: .public)")
+            throw ValidationError("Collection not found")
+        }
+
         collectionItem.collectionId = toCollectionId
         collectionItem.collection = collection
         collectionItem.position = position

--- a/ios/OffloadTests/CollectionItemRepositoryTests.swift
+++ b/ios/OffloadTests/CollectionItemRepositoryTests.swift
@@ -152,4 +152,61 @@ final class CollectionItemRepositoryTests: XCTestCase {
         )
         XCTAssertEqual(page.map(\.itemId), [item1.id, item2.id])
     }
+
+    func testAddItemToCollection_ThrowsWhenCollectionNotFound() async throws {
+        let item = try itemRepository.create(content: "Test Item")
+        let invalidCollectionId = UUID()
+
+        do {
+            _ = try collectionItemRepository.addItemToCollection(
+                itemId: item.id,
+                collectionId: invalidCollectionId
+            )
+            XCTFail("Expected ValidationError to be thrown")
+        } catch let error as ValidationError {
+            XCTAssertEqual(error.message, "Collection not found")
+        } catch {
+            XCTFail("Expected ValidationError but got \(error)")
+        }
+    }
+
+    func testAddItemToCollection_ThrowsWhenItemNotFound() async throws {
+        let collection = try collectionRepository.create(name: "Test Plan", isStructured: true)
+        let invalidItemId = UUID()
+
+        do {
+            _ = try collectionItemRepository.addItemToCollection(
+                itemId: invalidItemId,
+                collectionId: collection.id
+            )
+            XCTFail("Expected ValidationError to be thrown")
+        } catch let error as ValidationError {
+            XCTAssertEqual(error.message, "Item not found")
+        } catch {
+            XCTFail("Expected ValidationError but got \(error)")
+        }
+    }
+
+    func testMoveItemToCollection_ThrowsWhenCollectionNotFound() async throws {
+        let collection1 = try collectionRepository.create(name: "Plan 1", isStructured: true)
+        let item = try itemRepository.create(content: "Test Item")
+        let collectionItem = try collectionItemRepository.addItemToCollection(
+            itemId: item.id,
+            collectionId: collection1.id
+        )
+
+        let invalidCollectionId = UUID()
+
+        do {
+            try collectionItemRepository.moveItemToCollection(
+                collectionItem: collectionItem,
+                toCollectionId: invalidCollectionId
+            )
+            XCTFail("Expected ValidationError to be thrown")
+        } catch let error as ValidationError {
+            XCTAssertEqual(error.message, "Collection not found")
+        } catch {
+            XCTFail("Expected ValidationError but got \(error)")
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Prevents data corruption by validating entity existence before creating CollectionItem relationships.

Fixes #147

## Problem

`CollectionItemRepository.addItemToCollection` and `moveItemToCollection` could persist `CollectionItem` rows with nil relationships when referenced items or collections didn't exist, causing:
- Silent data corruption  
- Crashes in `fetchPage` when sorting by `item?.createdAt` on orphaned rows
- Inconsistent database state

## Solution

Added validation guards that:
1. Check if collection exists after fetch - throw `ValidationError` if not found
2. Check if item exists after fetch - throw `ValidationError` if not found  
3. Log errors with AppLogger.persistence for debugging
4. Prevent orphaned rows from being persisted

## Changes

### Code

1. **CollectionItemRepository.swift**
   - Added OSLog import for AppLogger
   - Updated `addItemToCollection` with collection and item validation guards
   - Updated `moveItemToCollection` with collection validation guard
   - Uses `ValidationError` for user-friendly error messages
   - Uses `AppLogger.persistence.error` for debugging with entity IDs

2. **CollectionItemRepositoryTests.swift**
   - Added `testAddItemToCollection_ThrowsWhenCollectionNotFound`
   - Added `testAddItemToCollection_ThrowsWhenItemNotFound`
   - Added `testMoveItemToCollection_ThrowsWhenCollectionNotFound`

3. **plan-fix-orphaned-collection-links.md**
   - Updated status to `in-progress`
   - Marked Phase 1 (Implementation) as complete
   - Marked Phase 2 (Test Coverage) as complete

### Testing

✅ **All new tests pass:**
- ValidationError thrown when collection not found
- ValidationError thrown when item not found  
- Correct error messages returned

✅ **All existing tests pass:**
- No regressions in valid ID scenarios
- Build succeeds with no warnings

## Implementation Plan

This PR implements **Phases 1 & 2** of [plan-fix-orphaned-collection-links.md](../blob/main/docs/plans/plan-fix-orphaned-collection-links.md):

- [x] Phase 1: Add Validation Guards
- [x] Phase 2: Add Test Coverage
- [ ] Phase 3: Verification (manual testing - can be UAT)
- [ ] Phase 4: Documentation

## Verification Steps

**Automated (complete):**
- ✅ Build succeeds  
- ✅ All repository tests pass
- ✅ New error case tests pass

**Manual (pending UAT):**
- Test drag-and-drop item to collection
- Delete collection mid-drag
- Verify error toast appears
- Verify no crash or data corruption

## Related

- **Issue:** #147
- **Plan:** [plan-fix-orphaned-collection-links.md](../blob/main/docs/plans/plan-fix-orphaned-collection-links.md)
- **Pattern:** Follows ValidationError pattern from ErrorHandling.swift
- **Logger:** Uses AppLogger.persistence pattern from other repositories

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)