### PR TITLE
fix(ci): use UDID destination in tests preflight

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -81,7 +81,17 @@ jobs:
           xcode-version: ${{ needs.bootstrap.outputs.ci_xcode_version }}
 
       - name: Preflight
-        run: scripts/ios/preflight.sh
+        env:
+          DEVICE_NAME: ${{ env.CI_SIM_DEVICE }}
+          OS_VERSION: ${{ env.CI_SIM_OS }}
+        run: |
+          set -euo pipefail
+          selection_output="$(scripts/ios/select-simulator.sh)"
+          selected_udid="$(printf '%s\n' "${selection_output}" | tail -n 1)"
+          while IFS= read -r line; do
+            echo "[INFO] ${line}"
+          done <<<"${selection_output}"
+          DESTINATION="platform=iOS Simulator,id=${selected_udid}" scripts/ios/preflight.sh
 
       - name: Write diagnostics report
         if: ${{ always() }}


### PR DESCRIPTION
## Summary
- update the iOS tests workflow preflight step to resolve a simulator UDID before validation
- pass a UDID-based destination into preflight instead of name plus OS matching
- align preflight behavior with the UDID path already used by scripts/ios/test.sh

## Why
- open PRs #153 and #154 were failing in the standalone preflight step due to strict name plus OS matching against xcodebuild showdestinations
- simulator existed in simctl, but showdestinations returned placeholder destinations at that stage

## Testing
- yamllint .github/workflows/ios-tests.yml
- inspected failing and passing Actions logs to confirm preflight divergence
