### PR TITLE
fix(ordering): prevent structured position collisions

### DIFF
--- a/ios/Offload/Features/Capture/CaptureSheets.swift
+++ b/ios/Offload/Features/Capture/CaptureSheets.swift
@@ -145,7 +145,7 @@ struct MoveToPlanSheet: View {
         guard let collection = selectedCollection else { return }
 
         do {
-            let position = collection.collectionItems?.count ?? 0
+            let position = collectionRepository.nextPosition(in: collection, parentId: nil)
             try itemRepository.moveToCollectionAtomically(item, collection: collection, targetType: "task", position: position)
 
             dismiss()

--- a/ios/Offload/Features/Organize/CollectionDetailSheets.swift
+++ b/ios/Offload/Features/Organize/CollectionDetailSheets.swift
@@ -453,7 +453,9 @@ struct AddItemSheet: View {
             throw ValidationError("Collection not found.")
         }
 
-        let position = targetCollection.isStructured ? (targetCollection.collectionItems?.count ?? 0) : nil
+        let position = targetCollection.isStructured
+            ? collectionRepository.nextPosition(in: targetCollection, parentId: nil)
+            : nil
         try itemRepository.moveToCollection(item, collection: targetCollection, position: position)
     }
 }

--- a/ios/Offload/Features/Organize/CollectionDetailView.swift
+++ b/ios/Offload/Features/Organize/CollectionDetailView.swift
@@ -430,9 +430,10 @@ struct CollectionDetailView: View {
                 // Nest as child of target
                 droppedItem.parentId = targetId
 
-                // Find position as last child of target
+                // Find next position among target's existing children.
                 let targetChildren = viewModel.items.filter { $0.parentId == targetId }
-                droppedItem.position = targetChildren.count
+                let nextChildPosition = (targetChildren.compactMap(\.position).max() ?? -1) + 1
+                droppedItem.position = nextChildPosition
 
                 // Expand the target to show the new child
                 expandedItems.insert(targetId)


### PR DESCRIPTION
## Summary
- replace count-based structured insertion with deterministic `max(position) + 1` logic
- compact structured sibling positions after delete to maintain contiguous ordering
- update capture/organize insertion call sites to use repository position helper
- add regression tests covering append-after-gaps and delete-then-append behavior

## Testing
- `just test`

Fixes #162