### PR TITLE
docs(readme): sync setup guidance and plans index

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ AI assistance.
 
 [badge-ios]: https://img.shields.io/badge/iOS-17.0+-blue.svg
 [link-ios]: https://www.apple.com/ios/
-[badge-swift]: https://img.shields.io/badge/Swift-5.9-orange.svg
+[badge-swift]: https://img.shields.io/badge/Swift-5.x-orange.svg
 [link-swift]: https://swift.org
 [badge-swiftui]: https://img.shields.io/badge/SwiftUI-5.0-green.svg
 [link-swiftui]: https://developer.apple.com/xcode/swiftui/
@@ -71,10 +71,12 @@ Active development. For current plans and milestones, see
 
 ## Getting Started
 
-Open the Xcode project and run the app:
+Use the project `just` commands:
 
 ```bash
-open ios/Offload.xcodeproj
+just xcode-open
+just build
+just test
 ```
 
 See `ios/README.md` for setup details.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -6,7 +6,7 @@ owners:
   - Will-Conklin
 applies_to:
   - plans
-last_updated: 2026-02-09
+last_updated: 2026-02-14
 related: []
 depends_on: []
 supersedes: []
@@ -77,16 +77,29 @@ proposed → accepted → in-progress → completed/archived
 - [Plan: Item Search by Text or Tag](./plan-item-search-tags.md)
 - [Plan: UX & Accessibility Audit Fixes](./plan-ux-accessibility-audit-fixes.md)
 - [Plan: View Decomposition](./plan-view-decomposition.md)
+- [Plan: Fix Swipe-to-Delete in Organize View](./plan-fix-swipe-to-delete.md)
+- [Plan: Resolve Gesture Conflict on Collection Cards](./plan-resolve-gesture-conflict.md)
+- [Plan: Atomic Move to Collection](./plan-fix-atomic-move-to-collection.md)
+- [Plan: Fix Orphaned Collection Links in CollectionItemRepository](./plan-fix-orphaned-collection-links.md)
+- [Plan: Fix Voice Recording Service Off-Main-Actor Mutations](./plan-fix-voice-recording-threading.md)
+- [Plan: Fix Collection Form Sheet Dismissing on Save Failure](./plan-fix-collection-form-dismissal.md)
+- [Plan: Tag Relationship Refactor (Pending Confirmation)](./plan-tag-relationship-refactor.md)
 
-### Proposed (Pending Confirmations)
+### Proposed
 
-- [Plan: Tag Relationship Refactor](./plan-tag-relationship-refactor.md)
-- [Plan: Visual Timeline](./plan-visual-timeline.md)
-- [Plan: Celebration Animations](./plan-celebration-animations.md)
-- [Plan: Advanced Accessibility Features](./plan-advanced-accessibility.md)
-- [Plan: AI Organization Flows & Review Screen](./plan-ai-organization-flows.md)
-- [Plan: AI Pricing & Limits](./plan-ai-pricing-limits.md)
-- [Plan: Backend API + Privacy Constraints](./plan-backend-api-privacy.md)
+- [Plan: Visual Timeline (Pending Confirmation)](./plan-visual-timeline.md)
+- [Plan: Celebration Animations (Pending Confirmation)](./plan-celebration-animations.md)
+- [Plan: Advanced Accessibility Features (Pending Confirmation)](./plan-advanced-accessibility.md)
+- [Plan: AI Organization Flows & Review Screen (Pending Confirmation)](./plan-ai-organization-flows.md)
+- [Plan: AI Pricing & Limits (Pending Confirmation)](./plan-ai-pricing-limits.md)
+- [Plan: Backend API + Privacy Constraints (Pending Confirmation)](./plan-backend-api-privacy.md)
+- [Plan: Fix Collection Position Backfill](./plan-fix-collection-position-backfill.md)
+- [Plan: Fix Structured Item Position Collisions](./plan-fix-structured-item-position-collisions.md)
+- [Plan: Fix Tag Usage Semantics](./plan-fix-tag-usage-semantics.md)
+
+### Completed
+
+- [Plan: Fix Tag Assignment Persistence](./plan-fix-tag-assignment.md)
 
 ### Archived
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -4,7 +4,7 @@
 SwiftUI iOS application for Offload — a friction-free thought capture and organization tool.
 
 [![iOS](https://img.shields.io/badge/iOS-17.0+-blue.svg)](https://www.apple.com/ios/)
-[![Swift](https://img.shields.io/badge/Swift-5.9-orange.svg)](https://swift.org)
+[![Swift](https://img.shields.io/badge/Swift-5.x-orange.svg)](https://swift.org)
 [![SwiftUI](https://img.shields.io/badge/SwiftUI-5.0-green.svg)](https://developer.apple.com/xcode/swiftui/)
 
 ## Table of Contents
@@ -71,14 +71,17 @@ See [../docs/adrs/adr-0001-technology-stack-and-architecture.md](../docs/adrs/ad
 
 ## Building & Running
 
-1. Open `Offload.xcodeproj` in Xcode
-2. Select a simulator or device
+1. Run `just xcode-open` from the repository root
+2. Select a simulator or device in Xcode
 3. Press Cmd+R to build and run
 
 ## Testing
 
 ### Running Tests
 
-Run tests with ⌘U in Xcode.
+Run tests with either:
+
+- `just test` from the repository root
+- ⌘U in Xcode
 
 See `docs/design/testing/README.md` for testing guides and checklists.


### PR DESCRIPTION
## Summary
- update root README setup commands to use `just xcode-open`, `just build`, and `just test`
- update iOS README build/test section to match current project workflow
- relax Swift badge version text to `5.x` in root and iOS READMEs
- refresh `docs/plans/README.md` canonical lists to match current in-progress/proposed/completed plan state

## Testing
- just lint-docs