### PR TITLE
docs: add docs→plan coverage review and register in research index

### DIFF
--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -302,6 +302,9 @@ sections:
       - id: research-2026-01-04-main-branch-review
         title: "Code Review: Main Branch - Comprehensive Analysis"
         path: research/reviews/research-2026-01-04-main-branch-review.md
+      - id: research-2026-02-14-docs-plan-coverage-review
+        title: "Docs → Plan Coverage Review (2026-02-14)"
+        path: research/reviews/research-2026-02-14-docs-plan-coverage-review.md
       - id: research-adhd-ux-ui
         title: ADHD-First UX and UI Guidance for Offload
         path: research/research-adhd-ux-ui.md

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -13,6 +13,7 @@ related:
   - research-color-scheme-alternatives
   - research-ios-ui-trends-2025
   - research-2026-01-04-main-branch-review
+  - research-2026-02-14-docs-plan-coverage-review
 depends_on: []
 supersedes: []
 accepted_by: null
@@ -65,6 +66,7 @@ active → completed
 - [Offline AI Quota Enforcement](./research-offline-ai-quota-enforcement.md)
 - [Privacy Implications of Learning from User Data](./research-privacy-learning-user-data.md)
 - [Code Review: Main Branch - Comprehensive Analysis](./reviews/research-2026-01-04-main-branch-review.md)
+- [Docs → Plan Coverage Review (2026-02-14)](./reviews/research-2026-02-14-docs-plan-coverage-review.md)
 
 ## Template
 

--- a/docs/research/reviews/README.md
+++ b/docs/research/reviews/README.md
@@ -9,6 +9,7 @@ applies_to:
 last_updated: 2026-01-25
 related:
   - research-2026-01-04-main-branch-review
+  - research-2026-02-14-docs-plan-coverage-review
 depends_on: []
 supersedes: []
 accepted_by: null
@@ -43,6 +44,7 @@ Research-level authority. Reviews are informational and must not define requirem
 ## Canonical documents
 
 - [Code Review: Main Branch - Comprehensive Analysis](./research-2026-01-04-main-branch-review.md)
+- [Docs → Plan Coverage Review (2026-02-14)](./research-2026-02-14-docs-plan-coverage-review.md)
 
 ## Naming
 

--- a/docs/research/reviews/research-2026-02-14-docs-plan-coverage-review.md
+++ b/docs/research/reviews/research-2026-02-14-docs-plan-coverage-review.md
@@ -1,0 +1,101 @@
+---
+id: research-2026-02-14-docs-plan-coverage-review
+type: research
+status: completed
+owners:
+  - Will-Conklin
+applies_to:
+  - docs
+  - plans
+last_updated: 2026-02-14
+related:
+  - plans-readme
+  - docs-agents
+  - prd-0001-product-requirements
+  - prd-0002-persistent-bottom-tab-bar
+  - prd-0003-convert-plans-lists
+  - prd-0004-drag-drop-ordering
+  - prd-0005-item-search-tags
+  - prd-0006-context-aware-ci-pipeline
+  - prd-0007-smart-task-breakdown
+  - prd-0008-brain-dump-compiler
+  - prd-0009-recurring-task-intelligence
+  - prd-0010-tone-assistant
+  - prd-0011-executive-function-prompts
+  - prd-0012-decision-fatigue-reducer
+  - prd-0013-pricing-limits
+  - design-voice-capture-testing-guide
+  - design-voice-capture-test-results
+depends_on: []
+supersedes: []
+accepted_by: null
+accepted_at: null
+related_issues: []
+structure_notes:
+  - "Section order: Scope Reviewed; Method; Coverage Summary; Findings; Recommendations; Follow-up Checklist."
+---
+
+# Docs → Plan Coverage Review (2026-02-14)
+
+## Scope Reviewed
+
+- Entire `docs/` tree with emphasis on authoritative artifacts and whether each documented component is represented by at least one plan entry in `docs/plans/` (active or archived).
+- Included directories: `prds/`, `adrs/`, `design/`, `reference/`, `plans/`, `discovery/`, `research/`.
+
+## Method
+
+1. Enumerate all documentation artifacts under `docs/`.
+2. Treat each PRD/design/reference feature document as a "component signal".
+3. Match component signals to plan coverage using:
+   - explicit `related` IDs in plan frontmatter,
+   - explicit `depends_on` links in plan frontmatter,
+   - topic-level parity when a plan exists for the same feature area.
+4. Flag gaps where no active/archived plan currently accounts for the component.
+
+## Coverage Summary
+
+- **PRD components:** 13/13 accounted for by existing plans.
+- **Design components (feature/design docs):** 7/9 explicitly accounted for by existing plans.
+- **Potential uncovered components:** 2 voice-capture testing artifacts.
+- **Plan catalog hygiene:** several plan files exist but are not indexed in `docs/index.yaml` (navigation gap, not scope gap).
+
+## Findings
+
+### 1) Core product and roadmap features are accounted for
+
+The following feature areas all have plan coverage:
+
+- Persistent Bottom Tab Bar (archived plan).
+- Convert Plans ↔ Lists.
+- Drag & Drop Ordering.
+- Item Search by Text/Tag.
+- Context-Aware CI Pipeline (archived plan).
+- AI/assistant feature cluster (smart breakdown, brain dump compiler, recurring intelligence, tone assistant, executive prompts, decision fatigue, pricing/limits) via `plan-ai-organization-flows` and `plan-ai-pricing-limits` plus backend/privacy dependency planning.
+
+### 2) Voice capture testing artifacts do not have explicit plan linkage
+
+The following accepted design/testing docs do not currently map to a dedicated plan by frontmatter linkage:
+
+- `docs/design/testing/design-voice-capture-testing-guide.md`
+- `docs/design/testing/design-voice-capture-test-results.md`
+
+There is related remediation work (`plan-fix-voice-recording-threading`), but the plan does not explicitly reference these artifacts in frontmatter. This is the strongest candidate for an "unaccounted component" depending on desired strictness.
+
+### 3) Documentation navigation index is incomplete for plans
+
+`docs/index.yaml` currently omits multiple active and archived plan files. This is a discoverability/governance issue and can mask coverage that already exists.
+
+## Recommendations
+
+1. **Resolve the voice-capture gap explicitly** (pick one):
+   - add `design-voice-capture-testing-guide` and `design-voice-capture-test-results` to `related` in `plan-fix-voice-recording-threading`, or
+   - create a dedicated voice-capture stabilization/testing plan if scope is broader than threading.
+2. **Update `docs/index.yaml`** to include all active plan files and omitted archived plan files to keep docs navigation authoritative for agents and humans.
+3. For future docs, enforce a lightweight rule: any new feature-focused design/testing doc should declare plan linkage (`depends_on` or reciprocal `related`) at creation time.
+
+## Follow-up Checklist
+
+- [ ] Decide whether voice-capture testing is fully covered by existing remediation plan.
+- [ ] If yes, update plan frontmatter links for traceability.
+- [ ] If no, create a dedicated plan and add it to `docs/index.yaml`.
+- [ ] Re-run this coverage review after index synchronization.


### PR DESCRIPTION
### Motivation

- Capture a snapshot audit of the `docs/` tree to validate that PRDs, designs, and reference artifacts have corresponding plans and to record any unaccounted components. 
- Persist the review findings in-repo so agents and humans can reference coverage gaps and recommended follow-ups.

### Description

- Added a new review file `docs/research/reviews/research-2026-02-14-docs-plan-coverage-review.md` containing coverage analysis, findings, and recommendations. 
- Registered the new review in `docs/research/reviews/README.md` and `docs/research/README.md` so it appears in canonical research/reviews lists. 
- Updated `docs/index.yaml` to include the new review entry under the Research section for discoverability.

### Testing

- Ran Python frontmatter enumeration and matching scripts to verify PRD/design/reference documents are mapped to plans and to produce the coverage summary, which completed successfully. 
- Verified presence and registration of the new review by searching for the review ID with `rg` and confirming the `docs/index.yaml` entry, which succeeded. 
- Compared file diffs and inspected the new file contents to confirm the review text, findings, and recommendations are present, which succeeded. 
- Attempted to run `markdownlint --fix` and `just lint` for linting, but those tools are not available in the environment so linting was skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69908f74f31c833092362002dba0600e)