### PR TITLE
fix: prevent duplicate collection positions during backfill

### DIFF
--- a/ios/Offload/Data/Repositories/CollectionRepository.swift
+++ b/ios/Offload/Data/Repositories/CollectionRepository.swift
@@ -345,10 +345,13 @@ final class CollectionRepository {
 
         AppLogger.general.info("Found \(collectionsNeedingPosition.count, privacy: .public) collections needing positions")
 
-        // Sort by creation date and assign positions
+        // Sort nil-position collections by creation date, appending after existing positions
         let sorted = collectionsNeedingPosition.sorted { $0.createdAt < $1.createdAt }
-        for (index, collection) in sorted.enumerated() {
-            collection.position = index
+        let maxExistingPosition = collections.compactMap(\.position).max() ?? -1
+        var nextPosition = maxExistingPosition + 1
+        for collection in sorted {
+            collection.position = nextPosition
+            nextPosition += 1
         }
 
         try modelContext.save()

--- a/ios/OffloadTests/CollectionRepositoryTests.swift
+++ b/ios/OffloadTests/CollectionRepositoryTests.swift
@@ -322,4 +322,23 @@ final class CollectionRepositoryTests: XCTestCase {
         XCTAssertTrue(plan.isStructured, "Plan should be structured (triggers warning)")
         XCTAssertFalse(list.isStructured, "List should not be structured (no warning)")
     }
+
+    func testBackfillCollectionPositions_AppendsAfterExistingPositionsForStructuredCollections() throws {
+        let existing = try collectionRepository.create(name: "Existing", isStructured: true)
+        existing.position = 7
+
+        let olderNil = try collectionRepository.create(name: "Older Nil", isStructured: true)
+        let newerNil = try collectionRepository.create(name: "Newer Nil", isStructured: true)
+        olderNil.position = nil
+        newerNil.position = nil
+        olderNil.createdAt = Date(timeIntervalSince1970: 1_000)
+        newerNil.createdAt = Date(timeIntervalSince1970: 2_000)
+        try modelContext.save()
+
+        try collectionRepository.backfillCollectionPositions(isStructured: true)
+
+        XCTAssertEqual(existing.position, 7)
+        XCTAssertEqual(olderNil.position, 8)
+        XCTAssertEqual(newerNil.position, 9)
+    }
 }


### PR DESCRIPTION
### Motivation
- Backfilling collection `position` values previously started at `0` for nil entries which could collide with existing positions in the same scope (structured vs unstructured). 
- This could cause unstable/incorrect ordering for plans and lists after migration or backfill.

### Description
- Update `backfillCollectionPositions(isStructured:)` to compute `maxExistingPosition = collections.compactMap(\.position).max() ?? -1` and assign nil-position collections starting at `maxExistingPosition + 1`. 
- Preserve deterministic ordering for newly-assigned positions by sorting nil-position collections by `createdAt` before assignment. 
- Add a unit test `testBackfillCollectionPositions_AppendsAfterExistingPositionsForStructuredCollections()` in `ios/OffloadTests/CollectionRepositoryTests.swift` to verify existing positions are preserved and nil entries are appended (e.g. `7 -> 8 -> 9`). 
- Files changed: `ios/Offload/Data/Repositories/CollectionRepository.swift` and `ios/OffloadTests/CollectionRepositoryTests.swift`.

### Testing
- Added an `XCTest` that asserts existing structured collection positions are preserved and newer nil-position collections are assigned sequential positions after the max existing position. 
- Attempted to run the CI-local test command `just test`, but the environment lacks `just` so the test suite could not be executed here. 
- Attempted `xcodebuild -version` to validate Xcode tooling, but `xcodebuild` is not available in this environment so platform test runs could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69913e318a40833090afbfc50ed72812)