### PR TITLE
fix: address adversarial review findings

### DIFF
--- a/backend/api/src/offload_backend/config.py
+++ b/backend/api/src/offload_backend/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import secrets
 from functools import lru_cache
 
 from pydantic import Field
@@ -14,7 +15,7 @@ class Settings(BaseSettings):
 
     environment: str = "development"
     build_version: str = "dev"
-    session_secret: str = "dev-secret-change-me"
+    session_secret: str = Field(default_factory=lambda: secrets.token_urlsafe(32))
     session_ttl_seconds: int = 3600
     openai_api_key: str | None = None
     openai_base_url: str = "https://api.openai.com/v1"

--- a/backend/api/src/offload_backend/schemas.py
+++ b/backend/api/src/offload_backend/schemas.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Annotated
 
 from pydantic import BaseModel, Field
 
@@ -26,8 +27,14 @@ class AnonymousSessionResponse(BaseModel):
 class BreakdownGenerateRequest(BaseModel):
     input_text: str = Field(min_length=1)
     granularity: int = Field(ge=1, le=5)
-    context_hints: list[str] = Field(default_factory=list)
-    template_ids: list[str] = Field(default_factory=list)
+    context_hints: list[Annotated[str, Field(min_length=1, max_length=280)]] = Field(
+        default_factory=list,
+        max_length=32,
+    )
+    template_ids: list[Annotated[str, Field(min_length=1, max_length=128)]] = Field(
+        default_factory=list,
+        max_length=32,
+    )
 
 
 class BreakdownStep(BaseModel):

--- a/backend/api/tests/test_config.py
+++ b/backend/api/tests/test_config.py
@@ -1,0 +1,14 @@
+from offload_backend.config import Settings
+
+
+def test_session_secret_default_is_not_static(monkeypatch):
+    monkeypatch.delenv("OFFLOAD_SESSION_SECRET", raising=False)
+
+    first = Settings().session_secret
+    second = Settings().session_secret
+
+    assert first
+    assert second
+    assert first != "dev-secret-change-me"
+    assert second != "dev-secret-change-me"
+    assert first != second

--- a/backend/api/tests/test_sessions_auth.py
+++ b/backend/api/tests/test_sessions_auth.py
@@ -50,6 +50,17 @@ def test_invalid_token_is_rejected(client):
     assert response.json()["error"]["code"] == "invalid_token"
 
 
+def test_malformed_base64_token_is_rejected(client):
+    response = client.post(
+        "/v1/usage/reconcile",
+        json={"install_id": "install-12345", "feature": "breakdown", "local_count": 1},
+        headers={"Authorization": "Bearer payload.!@#$"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "invalid_token"
+
+
 def test_expired_token_is_rejected(client):
     manager = TokenManager(secret="test-secret")
     expired_claims = SessionClaims(

--- a/ios/Offload/Data/Services/BreakdownService.swift
+++ b/ios/Offload/Data/Services/BreakdownService.swift
@@ -113,7 +113,7 @@ final class DefaultBreakdownService: BreakdownService {
                 source: .cloud,
                 usage: cloudResponse.usage
             )
-        } catch {
+        } catch let error as AIBackendClientError where error.shouldFallbackToOnDevice {
             let steps = try await onDeviceGenerator.generateBreakdown(
                 inputText: inputText,
                 granularity: granularity,
@@ -121,6 +121,8 @@ final class DefaultBreakdownService: BreakdownService {
                 templateIds: templateIds
             )
             return BreakdownExecutionResult(steps: steps, source: .onDevice, usage: nil)
+        } catch {
+            throw error
         }
     }
 

--- a/ios/OffloadTests/APIClientTests.swift
+++ b/ios/OffloadTests/APIClientTests.swift
@@ -1,0 +1,32 @@
+// Purpose: Unit tests for API client URL resolution.
+// Authority: Code-level
+// Governed by: AGENTS.md
+
+@testable import Offload
+import Foundation
+import XCTest
+
+final class APIClientTests: XCTestCase {
+    func testResolvedURLPreservesBasePathPrefixForLeadingSlashPath() {
+        let client = APIClient(
+            session: URLSession(configuration: .ephemeral),
+            baseURL: URL(string: "https://api.offload.app/api")!
+        )
+
+        let resolved = client.resolvedURL(for: "/v1/health")
+        XCTAssertEqual(resolved?.absoluteString, "https://api.offload.app/api/v1/health")
+    }
+
+    func testResolvedURLPreservesBasePathPrefixAndQuery() {
+        let client = APIClient(
+            session: URLSession(configuration: .ephemeral),
+            baseURL: URL(string: "https://api.offload.app/api/")!
+        )
+
+        let resolved = client.resolvedURL(for: "/v1/usage/reconcile?feature=breakdown")
+        XCTAssertEqual(
+            resolved?.absoluteString,
+            "https://api.offload.app/api/v1/usage/reconcile?feature=breakdown"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- replay follow-up review fixes on a fresh branch from current `main` to remove merge conflicts
- fix API base URL resolution so configured path prefixes (for example `/api`) are preserved
- harden backend token parsing so malformed base64 tokens map to `401 invalid_token`
- close request-size bypass by bounding `context_hints`/`template_ids` and enforcing aggregate content size
- replace static default session secret with randomized default generation
- keep practical-middle fallback behavior (transient failures fallback on-device; policy/auth failures surface)
- add regression tests for URL resolution, malformed token handling, aggregate payload limits, randomized secrets, and fallback policy

## Testing
- `just test`
- `cd backend/api && uv run --extra dev ruff check src tests`
- `cd backend/api && uv run --extra dev ty check src tests`
- `cd backend/api && uv run --extra dev pytest tests -q`

Replaces #185.