### PR TITLE
docs: add remediation plans for 2026-02-15 review findings

### DIFF
--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -297,6 +297,18 @@ sections:
       - id: plan-backend-api-privacy
         title: "Plan: Backend API + Privacy Constraints MVP (Breakdown-First)"
         path: plans/plan-backend-api-privacy.md
+      - id: plan-backend-session-security-hardening
+        title: "Plan: Backend Session Security Hardening"
+        path: plans/plan-backend-session-security-hardening.md
+      - id: plan-backend-reliability-durability
+        title: "Plan: Backend Reliability and Durability Hardening"
+        path: plans/plan-backend-reliability-durability.md
+      - id: plan-ios-data-performance-hardening
+        title: "Plan: iOS Data and Performance Hardening"
+        path: plans/plan-ios-data-performance-hardening.md
+      - id: plan-tab-shell-accessibility-hardening
+        title: "Plan: Tab Shell Accessibility Hardening"
+        path: plans/plan-tab-shell-accessibility-hardening.md
       - id: plan-archived-error-handling-improvements
         title: Error Handling Improvements Plan
         path: plans/_archived/plan-archived-error-handling-improvements.md

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -6,7 +6,7 @@ owners:
   - Will-Conklin
 applies_to:
   - plans
-last_updated: 2026-02-15
+last_updated: 2026-02-16
 related: []
 depends_on: []
 supersedes: []
@@ -92,6 +92,10 @@ proposed → accepted → in-progress → completed/archived
 
 ### Proposed
 
+- [Plan: Backend Session Security Hardening](./plan-backend-session-security-hardening.md)
+- [Plan: Backend Reliability and Durability Hardening](./plan-backend-reliability-durability.md)
+- [Plan: iOS Data and Performance Hardening](./plan-ios-data-performance-hardening.md)
+- [Plan: Tab Shell Accessibility Hardening](./plan-tab-shell-accessibility-hardening.md)
 - [Plan: Visual Timeline (Pending Confirmation)](./plan-visual-timeline.md)
 - [Plan: Celebration Animations (Pending Confirmation)](./plan-celebration-animations.md)
 - [Plan: Advanced Accessibility Features (Pending Confirmation)](./plan-advanced-accessibility.md)

--- a/docs/plans/plan-backend-reliability-durability.md
+++ b/docs/plans/plan-backend-reliability-durability.md
@@ -1,0 +1,115 @@
+---
+id: plan-backend-reliability-durability
+type: plan
+status: proposed
+owners:
+  - Will-Conklin
+applies_to:
+  - backend
+  - ai
+  - reliability
+last_updated: 2026-02-16
+related:
+  - plan-backend-api-privacy
+  - adr-0008-backend-api-privacy-mvp
+  - design-backend-api-privacy-mvp
+depends_on:
+  - docs/adrs/adr-0008-backend-api-privacy-mvp.md
+  - docs/design/design-backend-api-privacy-mvp.md
+supersedes: []
+accepted_by: null
+accepted_at: null
+related_issues: []
+structure_notes:
+  - "Section order: Overview; Goals; Phases; Dependencies; Risks; User Verification; Progress."
+---
+
+# Plan: Backend Reliability and Durability Hardening
+
+## Overview
+
+This plan upgrades backend durability and provider resilience for Smart Task
+Breakdown by replacing in-memory usage reconciliation with SQLite-backed
+persistence and adding bounded provider retry/backoff behavior. It also includes
+explicit regression verification for already-fixed payload guardrails.
+
+## Goals
+
+- Replace volatile in-memory usage reconciliation with durable SQLite storage.
+- Ensure reconcile writes are atomic and correct under concurrency.
+- Add bounded retry/backoff for transient provider failures.
+- Preserve and verify request-size and list-field guardrails.
+
+## Phases
+
+### Phase 1: Guardrail Verification Lock (Already Fixed)
+
+**Status:** Not Started
+
+- [ ] Red:
+  - [ ] Add boundary tests for `context_hints`/`template_ids` list lengths and
+        per-element max lengths.
+  - [ ] Add tests proving aggregate request size rejects oversized combined
+        payloads.
+- [ ] Green: keep existing schema/router enforcement intact while adding any
+      missing assertions.
+- [ ] Refactor: consolidate breakdown request fixture builders.
+
+### Phase 2: Durable Usage Store (SQLite First)
+
+**Status:** Not Started
+
+- [ ] Red:
+  - [ ] Add usage-store contract tests for persistence across app restart.
+  - [ ] Add concurrency tests verifying atomic `max(local, server)` upsert
+        semantics.
+- [ ] Green:
+  - [ ] Introduce usage store protocol and SQLite implementation.
+  - [ ] Wire app dependencies to use SQLite store by default.
+  - [ ] Preserve API response shape for `/v1/usage/reconcile`.
+- [ ] Refactor:
+  - [ ] Separate schema/bootstrap from reconcile operations.
+  - [ ] Add deterministic test database setup helpers.
+
+### Phase 3: Provider Retry and Backoff
+
+**Status:** Not Started
+
+- [ ] Red:
+  - [ ] Add adapter tests for retries on timeout/429/5xx and no-retry behavior
+        on non-retriable 4xx.
+  - [ ] Add tests that bound max attempts and total delay.
+- [ ] Green:
+  - [ ] Implement bounded exponential backoff with jitter for transient
+        provider errors.
+  - [ ] Add telemetry tags for attempt count and terminal error class.
+- [ ] Refactor:
+  - [ ] Extract retry policy into reusable configuration.
+  - [ ] Keep provider error mapping stable at router boundary.
+
+## Dependencies
+
+- [plan-backend-api-privacy](./plan-backend-api-privacy.md)
+- [adr-0008-backend-api-privacy-mvp](../adrs/adr-0008-backend-api-privacy-mvp.md)
+- [design-backend-api-privacy-mvp](../design/design-backend-api-privacy-mvp.md)
+
+## Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| SQLite locking behavior causes intermittent reconcile failures | M | Use explicit transactions and test concurrent write scenarios. |
+| Retry policy increases response latency under provider degradation | M | Bound attempts and enforce max timeout budget per request. |
+| Regression in existing payload guards | M | Keep phase-1 regression tests required before merge. |
+
+## User Verification
+
+- [ ] Usage counters persist across backend restart.
+- [ ] Reconcile behavior remains monotonic (`max(local, server)`) under repeated sync cycles.
+- [ ] Breakdown generation remains available during transient provider failures with bounded latency impact.
+- [ ] Oversized list-field payloads are rejected with stable error responses.
+
+## Progress
+
+| Date | Update |
+| --- | --- |
+| 2026-02-16 | Plan created from CODE_REVIEW_2026-02-15 reliability/performance backend findings split. |

--- a/docs/plans/plan-backend-session-security-hardening.md
+++ b/docs/plans/plan-backend-session-security-hardening.md
@@ -1,0 +1,128 @@
+---
+id: plan-backend-session-security-hardening
+type: plan
+status: proposed
+owners:
+  - Will-Conklin
+applies_to:
+  - backend
+  - ai
+  - security
+last_updated: 2026-02-16
+related:
+  - plan-backend-api-privacy
+  - adr-0008-backend-api-privacy-mvp
+  - design-backend-api-privacy-mvp
+depends_on:
+  - docs/adrs/adr-0008-backend-api-privacy-mvp.md
+  - docs/design/design-backend-api-privacy-mvp.md
+supersedes: []
+accepted_by: null
+accepted_at: null
+related_issues: []
+structure_notes:
+  - "Section order: Overview; Goals; Phases; Dependencies; Risks; User Verification; Progress."
+---
+
+# Plan: Backend Session Security Hardening
+
+## Overview
+
+This plan hardens anonymous session and token security for the backend MVP by
+adding production-safe secret policy enforcement, abuse controls on session
+issuance, and token metadata/version upgrades for key rotation readiness.
+
+## Goals
+
+- Enforce explicit production-safe session secret policy on startup.
+- Add rate limiting for `POST /v1/sessions/anonymous` using IP and install ID
+  signals.
+- Upgrade session token format to versioned claims with key metadata and strict
+  validation.
+- Preserve stable API error codes for unauthorized/invalid/expired token paths.
+
+## Phases
+
+### Phase 1: Baseline Verification and Regression Lock
+
+**Status:** Not Started
+
+- [ ] Add tests that lock in current fixed behavior:
+  - [ ] Malformed base64 and malformed token segments return `invalid_token`.
+  - [ ] Session secret default is non-static and non-reused across
+        instantiations.
+- [ ] Add tests that verify existing auth error code contracts remain stable.
+- [ ] Refactor auth test helpers for reusable token/session fixtures.
+
+### Phase 2: Production Secret Policy Enforcement
+
+**Status:** Not Started
+
+- [ ] Red:
+  - [ ] Add startup/config tests for production-like environments requiring
+        explicit `OFFLOAD_SESSION_SECRET`.
+  - [ ] Add tests rejecting weak or placeholder secret values.
+- [ ] Green:
+  - [ ] Implement config validation that fails closed when secrets are missing
+        or weak outside development.
+  - [ ] Add explicit runtime guidance in backend docs.
+- [ ] Refactor: centralize secret strength validation in a dedicated utility.
+
+### Phase 3: Session Issuance Rate Limiting
+
+**Status:** Not Started
+
+- [ ] Red:
+  - [ ] Add tests for per-IP and per-install throttling behavior on
+        `/v1/sessions/anonymous`.
+  - [ ] Add tests for deterministic `429` error envelope and reset behavior.
+- [ ] Green:
+  - [ ] Implement rate limiting dependency/middleware for session issuance.
+  - [ ] Emit bounded, non-sensitive telemetry for throttled events.
+- [ ] Refactor: extract limiter interface to support future storage-backed
+      implementations.
+
+### Phase 4: Token V2 Claims and Key Metadata (Hard Cutover)
+
+**Status:** Not Started
+
+- [ ] Red:
+  - [ ] Add tests requiring claims: `v`, `kid`, `iat`, `nbf`, `iss`, `aud`,
+        `exp`, `install_id`.
+  - [ ] Add tests requiring strict issuer/audience/key-id validation.
+  - [ ] Add tests verifying v1 tokens are rejected after cutover.
+- [ ] Green:
+  - [ ] Implement token v2 encode/decode with key-id aware signing and
+        constant-time signature checks.
+  - [ ] Add token configuration for issuer, audience, active key ID, and key
+        material.
+- [ ] Refactor:
+  - [ ] Inject deterministic clock for tests.
+  - [ ] Consolidate claim parsing and validation error mapping.
+
+## Dependencies
+
+- [plan-backend-api-privacy](./plan-backend-api-privacy.md)
+- [adr-0008-backend-api-privacy-mvp](../adrs/adr-0008-backend-api-privacy-mvp.md)
+- [design-backend-api-privacy-mvp](../design/design-backend-api-privacy-mvp.md)
+
+## Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Overly strict secret policy blocks local/dev workflows | M | Restrict fail-fast enforcement to production-like environments with clear dev bypass defaults. |
+| Aggressive rate limits impact legitimate users | M | Start conservative, test boundary behavior, and tune with telemetry. |
+| Hard token cutover causes short-lived session churn | M | Document rollout expectations and retest session refresh paths in iOS client integration tests. |
+
+## User Verification
+
+- [ ] Production deployment fails closed when secret policy is not satisfied.
+- [ ] Session issuance throttles as expected under abusive request rates.
+- [ ] Auth-protected endpoint behavior remains stable for missing/invalid/expired tokens.
+- [ ] New token format validates end-to-end in backend + iOS integration flows.
+
+## Progress
+
+| Date | Update |
+| --- | --- |
+| 2026-02-16 | Plan created from CODE_REVIEW_2026-02-15 security findings split. |

--- a/docs/plans/plan-ios-data-performance-hardening.md
+++ b/docs/plans/plan-ios-data-performance-hardening.md
@@ -1,0 +1,116 @@
+---
+id: plan-ios-data-performance-hardening
+type: plan
+status: proposed
+owners:
+  - Will-Conklin
+applies_to:
+  - ios
+  - performance
+  - persistence
+last_updated: 2026-02-16
+related:
+  - prd-0001-product-requirements
+  - prd-0007-smart-task-breakdown
+  - adr-0005-collection-ordering-and-hierarchy-persistence
+depends_on:
+  - docs/prds/prd-0001-product-requirements.md
+  - docs/adrs/adr-0005-collection-ordering-and-hierarchy-persistence.md
+supersedes: []
+accepted_by: null
+accepted_at: null
+related_issues: []
+structure_notes:
+  - "Section order: Overview; Goals; Phases; Dependencies; Risks; User Verification; Progress."
+---
+
+# Plan: iOS Data and Performance Hardening
+
+## Overview
+
+This plan addresses iOS data-layer performance and storage findings with one
+cohesive migration path: O(n) reorder behavior, file-backed attachments with
+lazy migration, and typed metadata access with backward compatibility.
+
+## Goals
+
+- Eliminate O(n^2) reorder paths in collection repositories.
+- Move attachment storage from inline SwiftData blob fields to file-backed
+  storage pointers.
+- Replace ad-hoc metadata JSON string handling with typed Codable accessors.
+- Preserve existing behavior and data compatibility during migration.
+
+## Phases
+
+### Phase 1: Reorder Complexity Refactor
+
+**Status:** Not Started
+
+- [ ] Red:
+  - [ ] Add repository tests for large reorder sets in `CollectionRepository`
+        and `CollectionItemRepository`.
+  - [ ] Add tests confirming structured/unstructured ordering behavior remains
+        unchanged.
+- [ ] Green:
+  - [ ] Replace repeated linear `first(where:)` lookups with dictionary indexes
+        keyed by `itemId`.
+  - [ ] Keep persisted position semantics unchanged.
+- [ ] Refactor: centralize reorder mapping helpers to avoid duplicated logic.
+
+### Phase 2: File-Backed Attachments with Lazy Migration
+
+**Status:** Not Started
+
+- [ ] Red:
+  - [ ] Add tests for reading legacy `attachmentData` and migrating on first
+        access/save.
+  - [ ] Add tests for attachment delete/update cleanup.
+- [ ] Green:
+  - [ ] Introduce attachment storage service with file path pointer metadata.
+  - [ ] Persist new attachments as files and update model references.
+  - [ ] Perform lazy migration from inline blobs to file storage.
+- [ ] Refactor:
+  - [ ] Consolidate image decode and storage utilities.
+  - [ ] Ensure errors map cleanly to existing user-facing error flows.
+
+### Phase 3: Typed Metadata Model (Typed Core + Extension Map)
+
+**Status:** Not Started
+
+- [ ] Red:
+  - [ ] Add tests for typed metadata encode/decode and unknown key
+        round-tripping.
+  - [ ] Add backward compatibility tests for existing JSON string payloads.
+- [ ] Green:
+  - [ ] Define Codable metadata type with core fields plus extension map.
+  - [ ] Add model/repository accessors that decode once per lifecycle.
+- [ ] Refactor:
+  - [ ] Remove duplicated JSONSerialization call sites.
+  - [ ] Keep compatibility bridge for older metadata values.
+
+## Dependencies
+
+- [prd-0001-product-requirements](../prds/prd-0001-product-requirements.md)
+- [prd-0007-smart-task-breakdown](../prds/prd-0007-smart-task-breakdown.md)
+- [adr-0005-collection-ordering-and-hierarchy-persistence](../adrs/adr-0005-collection-ordering-and-hierarchy-persistence.md)
+
+## Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Data migration bug causes attachment loss | H | Use lazy migration with rollback-safe legacy fallback and backup verification tests. |
+| Reorder refactor changes ordering semantics | M | Lock behavior with pre/post regression tests before optimization. |
+| Metadata typing breaks unknown future fields | M | Preserve extension map and round-trip unknown keys in tests. |
+
+## User Verification
+
+- [ ] Reordering remains correct and responsive in large collections.
+- [ ] Existing items with attachments remain visible after migration.
+- [ ] New attachment create/update/remove flows remain stable.
+- [ ] Metadata-driven UI behavior remains unchanged for existing records.
+
+## Progress
+
+| Date | Update |
+| --- | --- |
+| 2026-02-16 | Plan created from CODE_REVIEW_2026-02-15 iOS performance/data integrity findings. |

--- a/docs/plans/plan-release-prep.md
+++ b/docs/plans/plan-release-prep.md
@@ -6,7 +6,7 @@ owners:
   - Will-Conklin
 applies_to:
   - launch-release
-last_updated: 2026-02-09
+last_updated: 2026-02-16
 related:
   - plan-roadmap
   - plan-testing-polish
@@ -36,6 +36,8 @@ metadata, and TestFlight distribution.
 - Prepare documentation and release notes for launch.
 - Finalize App Store metadata and assets.
 - Distribute builds via TestFlight for final validation.
+- Complete a security release gate checklist aligned with backend privacy and
+  session-security behavior.
 
 ## Phases
 
@@ -71,6 +73,17 @@ metadata, and TestFlight distribution.
 - [ ] Distribute build and establish feedback window (minimum 1 week).
 - [ ] Triage TestFlight feedback and create issues for blockers.
 
+### Phase 4: Security Release Gate
+
+**Status:** Not Started
+
+- [ ] Validate production secret policy is satisfied in deployed environment.
+- [ ] Validate session issuance rate limiting is enabled and monitored.
+- [ ] Confirm privacy policy and retention statements match implemented backend
+      behavior (no prompt/response durable persistence).
+- [ ] Confirm incident response + rollback runbook is current and available.
+- [ ] Record gate sign-off and link blocking issues for any unmet criteria.
+
 ## Dependencies
 
 - Completion of testing and polish: [plan-testing-polish](./plan-testing-polish.md)
@@ -96,3 +109,4 @@ metadata, and TestFlight distribution.
 | --- | --- |
 | 2026-01-20 | Plan created from roadmap split. |
 | 2026-02-09 | Plan refined with concrete tasks and cross-references. |
+| 2026-02-16 | Added security release gate checklist aligned with backend hardening review recommendations. |

--- a/docs/plans/plan-tab-shell-accessibility-hardening.md
+++ b/docs/plans/plan-tab-shell-accessibility-hardening.md
@@ -1,0 +1,114 @@
+---
+id: plan-tab-shell-accessibility-hardening
+type: plan
+status: proposed
+owners:
+  - Will-Conklin
+applies_to:
+  - ios
+  - ux
+  - accessibility
+last_updated: 2026-02-16
+related:
+  - prd-0002-persistent-bottom-tab-bar
+  - adr-0003-adhd-focused-ux-ui-guardrails
+  - adr-0004-tab-bar-navigation-shell-and-offload-cta
+  - design-persistent-bottom-tab-bar
+  - plan-ux-accessibility-audit-fixes
+depends_on:
+  - docs/prds/prd-0002-persistent-bottom-tab-bar.md
+  - docs/adrs/adr-0003-adhd-focused-ux-ui-guardrails.md
+  - docs/adrs/adr-0004-tab-bar-navigation-shell-and-offload-cta.md
+  - docs/design/design-persistent-bottom-tab-bar.md
+supersedes: []
+accepted_by: null
+accepted_at: null
+related_issues: []
+structure_notes:
+  - "Section order: Overview; Goals; Phases; Dependencies; Risks; User Verification; Progress."
+---
+
+# Plan: Tab Shell Accessibility Hardening
+
+## Overview
+
+This plan hardens the custom tab shell and floating Offload CTA for consistent
+accessibility and adaptability by replacing remaining hardcoded metrics with
+theme tokens and adding explicit VoiceOver and Dynamic Type validation.
+
+## Goals
+
+- Route tab shell and CTA spacing/sizing constants through design tokens.
+- Verify and improve VoiceOver labels, focus order, and hit targets.
+- Validate Dynamic Type and reduced-motion behavior for tab shell interactions.
+- Keep UI behavior aligned with ADR-0003 and ADR-0004 guardrails.
+
+## Phases
+
+### Phase 1: Tokenize Tab Shell Metrics
+
+**Status:** Not Started
+
+- [ ] Red:
+  - [ ] Add layout snapshot/assertion tests across key device classes and
+        dynamic type sizes.
+  - [ ] Add tests locking tap-target minimum sizes for tab and CTA actions.
+- [ ] Green:
+  - [ ] Replace hardcoded tab shell constants (heights, divider sizes, spacers,
+        offsets) with `Theme.*` tokens.
+  - [ ] Keep current visual hierarchy and interaction affordances.
+- [ ] Refactor: group tab-shell-specific tokens under a dedicated theme namespace.
+
+### Phase 2: VoiceOver and Focus Order Hardening
+
+**Status:** Not Started
+
+- [ ] Red:
+  - [ ] Add UI/accessibility tests for VoiceOver labels/hints/values on tab and
+        CTA actions.
+  - [ ] Add traversal-order tests for expanded quick action tray.
+- [ ] Green:
+  - [ ] Ensure explicit labels/hints/traits for all tab and CTA controls.
+  - [ ] Ensure predictable focus order for expanded and collapsed CTA states.
+- [ ] Refactor: extract reusable accessibility modifiers for tab-shell controls.
+
+### Phase 3: Dynamic Type and Reduced Motion Validation
+
+**Status:** Not Started
+
+- [ ] Red:
+  - [ ] Add validation tests for no clipping/overlap at larger content sizes.
+  - [ ] Add tests for reduced-motion animation/transition behavior.
+- [ ] Green:
+  - [ ] Adjust tab/CTA layout and transitions to maintain readability and
+        stability under accessibility settings.
+- [ ] Refactor: remove duplicated animation guards and keep a single motion
+      policy path.
+
+## Dependencies
+
+- [prd-0002-persistent-bottom-tab-bar](../prds/prd-0002-persistent-bottom-tab-bar.md)
+- [adr-0003-adhd-focused-ux-ui-guardrails](../adrs/adr-0003-adhd-focused-ux-ui-guardrails.md)
+- [adr-0004-tab-bar-navigation-shell-and-offload-cta](../adrs/adr-0004-tab-bar-navigation-shell-and-offload-cta.md)
+- [design-persistent-bottom-tab-bar](../design/design-persistent-bottom-tab-bar.md)
+
+## Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Tokenization drifts from approved visual behavior | M | Use before/after screenshots and snapshot baselines. |
+| Accessibility fixes alter expected gesture flows | M | Pair UI tests with manual VoiceOver walkthrough before merge. |
+| Large Dynamic Type causes crowded CTA tray | M | Define explicit fallback spacing and wrapping behavior in token set. |
+
+## User Verification
+
+- [ ] Tab and CTA controls remain easy to use with VoiceOver enabled.
+- [ ] Dynamic Type sizes up to accessibility categories avoid clipping/overlap.
+- [ ] Reduced Motion setting removes non-essential motion while preserving clarity.
+- [ ] Visual style remains consistent with approved tab shell design language.
+
+## Progress
+
+| Date | Update |
+| --- | --- |
+| 2026-02-16 | Plan created from CODE_REVIEW_2026-02-15 UX/accessibility consistency findings. |

--- a/docs/plans/plan-testing-polish.md
+++ b/docs/plans/plan-testing-polish.md
@@ -6,10 +6,11 @@ owners:
   - Will-Conklin
 applies_to:
   - launch-release
-last_updated: 2026-02-09
+last_updated: 2026-02-16
 related:
   - plan-roadmap
   - plan-ux-accessibility-audit-fixes
+  - plan-tab-shell-accessibility-hardening
   - design-manual-testing-checklist
   - design-manual-testing-results
   - prd-0001-product-requirements
@@ -42,6 +43,8 @@ and accessibility review before release prep begins.
   scope.
 - Resolve defects discovered during manual testing.
 - Confirm accessibility, permissions, and offline behavior are stable for launch.
+- Enforce explicit non-functional launch gates (latency, startup, memory,
+  crash-free health) before release prep.
 
 ## Phases
 
@@ -65,6 +68,8 @@ and accessibility review before release prep begins.
 
 - [ ] Capture baseline launch and navigation timing notes.
 - [ ] Run pagination flows under large data sets.
+- [ ] Measure backend breakdown latency and track p95 under representative load.
+- [ ] Capture startup-time and idle-memory baselines on physical devices.
 - [ ] Document any regressions or slow paths to address in Phase 3.
 
 ### Phase 3: Bug Fixes & Polish
@@ -86,7 +91,23 @@ This phase validates that work and catches any remaining gaps.
 
 - [ ] Review VoiceOver support for core views.
 - [ ] Validate contrast, tap targets, and focus order.
+- [ ] Validate custom tab shell and floating CTA VoiceOver traversal end-to-end.
+- [ ] Validate Dynamic Type layout at accessibility sizes for tab shell + CTA
+      quick actions.
 - [ ] Log any launch blockers and confirm resolution.
+
+### Phase 5: Non-Functional Launch Gates
+
+**Status:** Not Started
+
+- [ ] Define and record release gate thresholds:
+  - [ ] Backend breakdown latency p95.
+  - [ ] iOS startup timing budget.
+  - [ ] iOS idle-memory budget.
+  - [ ] TestFlight crash-free goal.
+- [ ] Verify observed metrics meet gate thresholds before entering release prep.
+- [ ] Record gate results in the testing artifacts and link blocking issues for
+      any misses.
 
 ## Dependencies
 
@@ -114,3 +135,4 @@ This phase validates that work and catches any remaining gaps.
 | --- | --- |
 | 2026-01-20 | Plan created from roadmap split. |
 | 2026-02-09 | Plan refined with cross-references to testing artifacts, PRDs, and accessibility audit. |
+| 2026-02-16 | Added non-functional launch gates and mandatory tab-shell accessibility validation tasks from review follow-up. |


### PR DESCRIPTION
## Summary
- add four split remediation plans from the 2026-02-15 review (backend session security, backend durability/reliability, iOS data/performance, tab shell accessibility)
- update existing in-progress plans with explicit non-functional launch gates and release security gate checklist
- update docs navigation/index entries for new plans

## Related Issues
- refs #189
- refs #190
- refs #191
- refs #192

## Testing
- just lint
