### PR TITLE
feat: add backend session issuance rate limiting

### DIFF
--- a/backend/api/src/offload_backend/config.py
+++ b/backend/api/src/offload_backend/config.py
@@ -22,6 +22,9 @@ class Settings(BaseSettings):
     build_version: str = "dev"
     session_secret: str = ""
     session_ttl_seconds: int = 3600
+    session_issue_limit_per_ip: int = Field(default=8, ge=1)
+    session_issue_limit_per_install: int = Field(default=4, ge=1)
+    session_issue_limit_window_seconds: int = Field(default=60, ge=1)
     openai_api_key: str | None = None
     openai_base_url: str = "https://api.openai.com/v1"
     openai_model: str = "gpt-4o-mini"

--- a/backend/api/src/offload_backend/routers/sessions.py
+++ b/backend/api/src/offload_backend/routers/sessions.py
@@ -1,24 +1,37 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 
 from offload_backend.config import Settings
-from offload_backend.dependencies import get_app_settings, get_token_manager
+from offload_backend.dependencies import (
+    enforce_session_issuance_rate_limit,
+    get_app_settings,
+    get_session_rate_limiter,
+    get_token_manager,
+)
 from offload_backend.schemas import AnonymousSessionRequest, AnonymousSessionResponse
 from offload_backend.security import TokenManager
+from offload_backend.session_rate_limiter import SessionRateLimiter
 
 router = APIRouter()
 
 
 @router.post("/sessions/anonymous", response_model=AnonymousSessionResponse)
 def create_anonymous_session(
-    request: AnonymousSessionRequest,
+    payload: AnonymousSessionRequest,
+    request: Request,
     token_manager: TokenManager = Depends(get_token_manager),
+    limiter: SessionRateLimiter = Depends(get_session_rate_limiter),
     settings: Settings = Depends(get_app_settings),
 ) -> AnonymousSessionResponse:
-    _ = (request.app_version, request.platform)
+    _ = (payload.app_version, payload.platform)
+    enforce_session_issuance_rate_limit(
+        install_id=payload.install_id,
+        request=request,
+        limiter=limiter,
+    )
     claims = token_manager.issue_session(
-        install_id=request.install_id,
+        install_id=payload.install_id,
         ttl_seconds=settings.session_ttl_seconds,
     )
     return AnonymousSessionResponse(

--- a/backend/api/src/offload_backend/session_rate_limiter.py
+++ b/backend/api/src/offload_backend/session_rate_limiter.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from threading import Lock
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class SessionRateLimitState:
+    count: int
+    window_started_at: datetime
+
+
+class SessionRateLimitExceeded(Exception):
+    def __init__(self, *, dimension: str, retry_after_seconds: int):
+        self.dimension = dimension
+        self.retry_after_seconds = retry_after_seconds
+        super().__init__(f"Session rate limit exceeded for {dimension}")
+
+
+class SessionRateLimiter(Protocol):
+    def check(self, *, client_ip: str, install_id: str) -> None: ...
+
+
+class InMemorySessionRateLimiter:
+    def __init__(
+        self,
+        *,
+        limit_per_ip: int,
+        limit_per_install: int,
+        window_seconds: int,
+        now_provider: Callable[[], datetime] | None = None,
+    ):
+        self._limit_per_ip = limit_per_ip
+        self._limit_per_install = limit_per_install
+        self._window_seconds = window_seconds
+        self._now_provider = now_provider or (lambda: datetime.now(UTC))
+        self._ip_windows: dict[str, SessionRateLimitState] = {}
+        self._install_windows: dict[str, SessionRateLimitState] = {}
+        self._lock = Lock()
+
+    def check(self, *, client_ip: str, install_id: str) -> None:
+        now = self._now_provider()
+        with self._lock:
+            self._ip_windows[client_ip] = self._consume(
+                state=self._ip_windows.get(client_ip),
+                limit=self._limit_per_ip,
+                now=now,
+                dimension="ip",
+            )
+            self._install_windows[install_id] = self._consume(
+                state=self._install_windows.get(install_id),
+                limit=self._limit_per_install,
+                now=now,
+                dimension="install_id",
+            )
+
+    def _consume(
+        self,
+        *,
+        state: SessionRateLimitState | None,
+        limit: int,
+        now: datetime,
+        dimension: str,
+    ) -> SessionRateLimitState:
+        if state is None:
+            return SessionRateLimitState(count=1, window_started_at=now)
+
+        elapsed = (now - state.window_started_at).total_seconds()
+        if elapsed >= self._window_seconds:
+            return SessionRateLimitState(count=1, window_started_at=now)
+
+        if state.count >= limit:
+            retry_after = max(1, int(self._window_seconds - elapsed))
+            raise SessionRateLimitExceeded(
+                dimension=dimension,
+                retry_after_seconds=retry_after,
+            )
+
+        return SessionRateLimitState(
+            count=state.count + 1,
+            window_started_at=state.window_started_at,
+        )

--- a/backend/api/tests/test_sessions_auth.py
+++ b/backend/api/tests/test_sessions_auth.py
@@ -1,8 +1,12 @@
 import base64
 import hashlib
 import hmac
+from datetime import UTC, datetime, timedelta
 
 import pytest
+
+from offload_backend.dependencies import get_session_rate_limiter
+from offload_backend.session_rate_limiter import InMemorySessionRateLimiter
 
 
 def _build_signed_token(payload_segment: str, secret: str = "test-secret") -> str:
@@ -13,6 +17,30 @@ def _build_signed_token(payload_segment: str, secret: str = "test-secret") -> st
     ).digest()
     signature_segment = base64.urlsafe_b64encode(signature).decode("utf-8").rstrip("=")
     return f"{payload_segment}.{signature_segment}"
+
+
+def _create_anonymous_session(
+    client,
+    *,
+    install_id: str,
+    ip: str,
+):
+    return client.post(
+        "/v1/sessions/anonymous",
+        json={"install_id": install_id, "app_version": "1.0", "platform": "ios"},
+        headers={"X-Forwarded-For": ip},
+    )
+
+
+class _ManualClock:
+    def __init__(self, start: datetime | None = None):
+        self._now = start or datetime.now(UTC)
+
+    def now(self) -> datetime:
+        return self._now
+
+    def advance(self, *, seconds: int) -> None:
+        self._now += timedelta(seconds=seconds)
 
 
 def test_session_issuance_returns_token_and_expiry(client):
@@ -26,6 +54,76 @@ def test_session_issuance_returns_token_and_expiry(client):
     assert isinstance(body["session_token"], str)
     assert body["session_token"]
     assert body["expires_at"]
+
+
+def test_anonymous_session_endpoint_rate_limits_per_ip(client, app):
+    limiter = InMemorySessionRateLimiter(
+        limit_per_ip=2,
+        limit_per_install=10,
+        window_seconds=60,
+    )
+    app.dependency_overrides[get_session_rate_limiter] = lambda: limiter
+
+    first = _create_anonymous_session(client, install_id="install-11111", ip="203.0.113.10")
+    second = _create_anonymous_session(client, install_id="install-22222", ip="203.0.113.10")
+    blocked = _create_anonymous_session(client, install_id="install-33333", ip="203.0.113.10")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert blocked.status_code == 429
+    assert blocked.json()["error"]["code"] == "session_rate_limited"
+
+    app.dependency_overrides.clear()
+
+
+def test_anonymous_session_endpoint_rate_limits_per_install_id(client, app):
+    limiter = InMemorySessionRateLimiter(
+        limit_per_ip=10,
+        limit_per_install=2,
+        window_seconds=60,
+    )
+    app.dependency_overrides[get_session_rate_limiter] = lambda: limiter
+
+    first = _create_anonymous_session(client, install_id="install-12345", ip="203.0.113.10")
+    second = _create_anonymous_session(client, install_id="install-12345", ip="203.0.113.11")
+    blocked = _create_anonymous_session(client, install_id="install-12345", ip="203.0.113.12")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert blocked.status_code == 429
+    assert blocked.json()["error"]["code"] == "session_rate_limited"
+
+    app.dependency_overrides.clear()
+
+
+def test_anonymous_session_rate_limit_resets_after_window(client, app):
+    clock = _ManualClock(start=datetime(2026, 2, 16, 12, 0, tzinfo=UTC))
+    limiter = InMemorySessionRateLimiter(
+        limit_per_ip=1,
+        limit_per_install=1,
+        window_seconds=60,
+        now_provider=clock.now,
+    )
+    app.dependency_overrides[get_session_rate_limiter] = lambda: limiter
+
+    allowed = _create_anonymous_session(client, install_id="install-12345", ip="203.0.113.10")
+    blocked = _create_anonymous_session(client, install_id="install-12345", ip="203.0.113.10")
+
+    assert allowed.status_code == 200
+    assert blocked.status_code == 429
+    assert blocked.json() == {
+        "error": {
+            "code": "session_rate_limited",
+            "message": "Too many session requests; retry later",
+            "request_id": blocked.json()["error"]["request_id"],
+        }
+    }
+
+    clock.advance(seconds=61)
+    reset = _create_anonymous_session(client, install_id="install-12345", ip="203.0.113.10")
+    assert reset.status_code == 200
+
+    app.dependency_overrides.clear()
 
 
 def test_malformed_base64_payload_token_is_rejected(post_usage_reconcile):

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -89,10 +89,10 @@ proposed → accepted → in-progress → completed/archived
 - [Plan: Diagnose Idle Memory Pressure](./plan-diagnose-idle-memory-pressure.md)
 - [Plan: Fix Collection Position Backfill](./plan-fix-collection-position-backfill.md)
 - [Plan: Backend API + Privacy Constraints MVP (Breakdown-First)](./plan-backend-api-privacy.md)
+- [Plan: Backend Session Security Hardening](./plan-backend-session-security-hardening.md)
 
 ### Proposed
 
-- [Plan: Backend Session Security Hardening](./plan-backend-session-security-hardening.md)
 - [Plan: Backend Reliability and Durability Hardening](./plan-backend-reliability-durability.md)
 - [Plan: iOS Data and Performance Hardening](./plan-ios-data-performance-hardening.md)
 - [Plan: Tab Shell Accessibility Hardening](./plan-tab-shell-accessibility-hardening.md)

--- a/docs/plans/plan-backend-session-security-hardening.md
+++ b/docs/plans/plan-backend-session-security-hardening.md
@@ -1,7 +1,7 @@
 ---
 id: plan-backend-session-security-hardening
 type: plan
-status: proposed
+status: in-progress
 owners:
   - Will-Conklin
 applies_to:
@@ -45,41 +45,41 @@ issuance, and token metadata/version upgrades for key rotation readiness.
 
 ### Phase 1: Baseline Verification and Regression Lock
 
-**Status:** Not Started
+**Status:** Completed
 
-- [ ] Add tests that lock in current fixed behavior:
-  - [ ] Malformed base64 and malformed token segments return `invalid_token`.
-  - [ ] Session secret default is non-static and non-reused across
+- [x] Add tests that lock in current fixed behavior:
+  - [x] Malformed base64 and malformed token segments return `invalid_token`.
+  - [x] Session secret default is non-static and non-reused across
         instantiations.
-- [ ] Add tests that verify existing auth error code contracts remain stable.
-- [ ] Refactor auth test helpers for reusable token/session fixtures.
+- [x] Add tests that verify existing auth error code contracts remain stable.
+- [x] Refactor auth test helpers for reusable token/session fixtures.
 
 ### Phase 2: Production Secret Policy Enforcement
 
-**Status:** Not Started
+**Status:** Completed
 
-- [ ] Red:
-  - [ ] Add startup/config tests for production-like environments requiring
+- [x] Red:
+  - [x] Add startup/config tests for production-like environments requiring
         explicit `OFFLOAD_SESSION_SECRET`.
-  - [ ] Add tests rejecting weak or placeholder secret values.
-- [ ] Green:
-  - [ ] Implement config validation that fails closed when secrets are missing
+  - [x] Add tests rejecting weak or placeholder secret values.
+- [x] Green:
+  - [x] Implement config validation that fails closed when secrets are missing
         or weak outside development.
-  - [ ] Add explicit runtime guidance in backend docs.
-- [ ] Refactor: centralize secret strength validation in a dedicated utility.
+  - [x] Add explicit runtime guidance in backend docs.
+- [x] Refactor: centralize secret strength validation in a dedicated utility.
 
 ### Phase 3: Session Issuance Rate Limiting
 
-**Status:** Not Started
+**Status:** Completed
 
-- [ ] Red:
-  - [ ] Add tests for per-IP and per-install throttling behavior on
+- [x] Red:
+  - [x] Add tests for per-IP and per-install throttling behavior on
         `/v1/sessions/anonymous`.
-  - [ ] Add tests for deterministic `429` error envelope and reset behavior.
-- [ ] Green:
-  - [ ] Implement rate limiting dependency/middleware for session issuance.
-  - [ ] Emit bounded, non-sensitive telemetry for throttled events.
-- [ ] Refactor: extract limiter interface to support future storage-backed
+  - [x] Add tests for deterministic `429` error envelope and reset behavior.
+- [x] Green:
+  - [x] Implement rate limiting dependency/middleware for session issuance.
+  - [x] Emit bounded, non-sensitive telemetry for throttled events.
+- [x] Refactor: extract limiter interface to support future storage-backed
       implementations.
 
 ### Phase 4: Token V2 Claims and Key Metadata (Hard Cutover)
@@ -126,3 +126,4 @@ issuance, and token metadata/version upgrades for key rotation readiness.
 | Date | Update |
 | --- | --- |
 | 2026-02-16 | Plan created from CODE_REVIEW_2026-02-15 security findings split. |
+| 2026-02-16 | Completed Phases 1-3: auth regression lock, production secret policy enforcement, and session issuance rate limiting with deterministic 429/reset behavior and bounded telemetry. |


### PR DESCRIPTION
## Summary
- add in-memory session issuance throttling for `POST /v1/sessions/anonymous` with separate per-IP and per-install limits
- enforce throttling in the session route with deterministic `429` API error behavior
- emit bounded throttle telemetry (request ID, path, dimension, retry-after, hashed install ID)
- add regression tests for per-IP throttling, per-install throttling, and reset-after-window behavior
- update backend session security plan tracking to mark Phases 1-3 completed and move the plan to In Progress in canonical plan index

## Testing
- `uv run --project backend/api --extra dev ruff check backend/api/src backend/api/tests`
- `uv run --project backend/api --extra dev ty check src tests` (from `backend/api`)
- `uv run --project backend/api --extra dev pytest backend/api/tests -q`
