### PR TITLE
feat: hard cutover backend session tokens to v2 claims

### DIFF
--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -9,6 +9,13 @@ Backend API package for Offload MVP services.
 - Production-like environments (`OFFLOAD_ENVIRONMENT` not in
   `dev/development/local/test/testing`): `OFFLOAD_SESSION_SECRET` is required
   and must be strong.
+- Session token v2 settings:
+  - `OFFLOAD_SESSION_TOKEN_ISSUER` (default: `offload-backend`)
+  - `OFFLOAD_SESSION_TOKEN_AUDIENCE` (default: `offload-ios`)
+  - `OFFLOAD_SESSION_TOKEN_ACTIVE_KID` (default: `v2-default`)
+  - optional `OFFLOAD_SESSION_SIGNING_KEYS` as JSON map for key rotation
+    (for example: `{"v2-default":"<secret>"}`); if omitted, active key uses
+    `OFFLOAD_SESSION_SECRET`.
 
 Example:
 

--- a/backend/api/src/offload_backend/dependencies.py
+++ b/backend/api/src/offload_backend/dependencies.py
@@ -36,7 +36,13 @@ def get_app_settings() -> Settings:
 
 
 def get_token_manager(settings: Settings = Depends(get_app_settings)) -> TokenManager:
-    return TokenManager(secret=settings.session_secret)
+    return TokenManager(
+        secret=settings.session_secret,
+        issuer=settings.session_token_issuer,
+        audience=settings.session_token_audience,
+        active_kid=settings.session_token_active_kid,
+        signing_keys=settings.session_signing_keys,
+    )
 
 
 def get_session_claims(

--- a/backend/api/src/offload_backend/security.py
+++ b/backend/api/src/offload_backend/security.py
@@ -5,9 +5,13 @@ import binascii
 import hashlib
 import hmac
 import json
+from collections.abc import Callable, Mapping
 from datetime import UTC, datetime, timedelta
 
 from pydantic import BaseModel, ConfigDict
+
+TOKEN_VERSION = 2
+REQUIRED_V2_CLAIMS = frozenset({"v", "kid", "iat", "nbf", "iss", "aud", "exp", "install_id"})
 
 
 class TokenError(Exception):
@@ -30,8 +34,28 @@ class SessionClaims(BaseModel):
 
 
 class TokenManager:
-    def __init__(self, secret: str):
-        self._secret = secret.encode("utf-8")
+    def __init__(
+        self,
+        secret: str,
+        *,
+        issuer: str = "offload-backend",
+        audience: str = "offload-ios",
+        active_kid: str = "v2-default",
+        signing_keys: Mapping[str, str] | None = None,
+        now_provider: Callable[[], datetime] | None = None,
+    ):
+        self._issuer = issuer.strip()
+        self._audience = audience.strip()
+        self._active_kid = active_kid.strip()
+        if not self._issuer or not self._audience or not self._active_kid:
+            raise ValueError("Token issuer, audience, and active_kid must be non-empty")
+
+        self._now_provider = now_provider or (lambda: datetime.now(UTC))
+        self._signing_keys = _build_signing_keys(
+            secret=secret,
+            active_kid=self._active_kid,
+            signing_keys=signing_keys,
+        )
 
     def issue_session(
         self,
@@ -39,28 +63,40 @@ class TokenManager:
         ttl_seconds: int,
         now: datetime | None = None,
     ) -> SessionClaims:
-        now = now or datetime.now(UTC)
+        now = now or self._now_provider()
         return SessionClaims(install_id=install_id, expires_at=now + timedelta(seconds=ttl_seconds))
 
     def encode(self, claims: SessionClaims) -> str:
+        issued_at = int(self._now_provider().timestamp())
         payload = {
+            "v": TOKEN_VERSION,
+            "kid": self._active_kid,
+            "iat": issued_at,
+            "nbf": issued_at,
+            "iss": self._issuer,
+            "aud": self._audience,
             "install_id": claims.install_id,
             "exp": int(claims.expires_at.timestamp()),
         }
-        payload_bytes = json.dumps(payload, separators=(",", ":")).encode("utf-8")
-        payload_b64 = base64.urlsafe_b64encode(payload_bytes).decode("utf-8").rstrip("=")
-        signature = hmac.new(self._secret, payload_b64.encode("utf-8"), hashlib.sha256).digest()
+        payload_b64 = _encode_payload(payload)
+        signature = hmac.new(
+            self._signing_keys[self._active_kid],
+            payload_b64.encode("utf-8"),
+            hashlib.sha256,
+        ).digest()
         signature_b64 = base64.urlsafe_b64encode(signature).decode("utf-8").rstrip("=")
         return f"{payload_b64}.{signature_b64}"
 
     def decode(self, token: str) -> SessionClaims:
-        try:
-            payload_b64, signature_b64 = token.split(".", maxsplit=1)
-        except ValueError as exc:
-            raise InvalidTokenError("Malformed session token") from exc
+        payload_b64, signature_b64 = _split_token(token)
+        payload = _decode_payload(payload_b64)
+        kid = _parse_key_id(payload)
+        signing_key = self._signing_keys.get(kid)
+        if signing_key is None:
+            raise InvalidTokenError("Unknown token key id")
 
         expected_signature = hmac.new(
-            self._secret,
+            signing_key,
             payload_b64.encode("utf-8"),
             hashlib.sha256,
         ).digest()
@@ -69,18 +105,122 @@ class TokenManager:
         if not hmac.compare_digest(expected_signature, provided_signature):
             raise InvalidTokenError("Token signature mismatch")
 
-        payload_bytes = _urlsafe_b64decode(payload_b64)
-        try:
-            payload = json.loads(payload_bytes.decode("utf-8"))
-            expires_at = datetime.fromtimestamp(int(payload["exp"]), tz=UTC)
-            install_id = str(payload["install_id"])
-        except (KeyError, TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-            raise InvalidTokenError("Invalid token payload") from exc
+        return self._parse_v2_claims(payload)
 
-        if expires_at <= datetime.now(UTC):
+    def _parse_v2_claims(self, payload: dict[str, object]) -> SessionClaims:
+        missing_claims = REQUIRED_V2_CLAIMS.difference(payload.keys())
+        if missing_claims:
+            raise InvalidTokenError("Missing token claims")
+
+        version = _require_int(payload, "v")
+        key_id = _require_str(payload, "kid")
+        issued_at = datetime.fromtimestamp(_require_int(payload, "iat"), tz=UTC)
+        not_before = datetime.fromtimestamp(_require_int(payload, "nbf"), tz=UTC)
+        issuer = _require_str(payload, "iss")
+        audience = _require_str(payload, "aud")
+        expires_at = datetime.fromtimestamp(_require_int(payload, "exp"), tz=UTC)
+        install_id = _require_str(payload, "install_id")
+
+        if version != TOKEN_VERSION:
+            raise InvalidTokenError("Unsupported token version")
+        if issuer != self._issuer:
+            raise InvalidTokenError("Token issuer mismatch")
+        if audience != self._audience:
+            raise InvalidTokenError("Token audience mismatch")
+        if key_id not in self._signing_keys:
+            raise InvalidTokenError("Unknown token key id")
+        if not_before < issued_at:
+            raise InvalidTokenError("Invalid token timing claims")
+
+        now = self._now_provider()
+        if now < not_before:
+            raise InvalidTokenError("Token not active yet")
+        if expires_at <= now:
             raise ExpiredTokenError("Token expired")
 
         return SessionClaims(install_id=install_id, expires_at=expires_at)
+
+
+def _build_signing_keys(
+    *,
+    secret: str,
+    active_kid: str,
+    signing_keys: Mapping[str, str] | None,
+) -> dict[str, bytes]:
+    normalized: dict[str, bytes] = {}
+    if signing_keys:
+        for kid, key in signing_keys.items():
+            normalized_kid = kid.strip()
+            normalized_key = key.strip()
+            if not normalized_kid or not normalized_key:
+                raise ValueError("Token signing keys must contain non-empty key IDs and values")
+            normalized[normalized_kid] = normalized_key.encode("utf-8")
+
+    if active_kid not in normalized:
+        fallback_secret = secret.strip()
+        if not fallback_secret:
+            raise ValueError("Missing key material for active token key ID")
+        normalized[active_kid] = fallback_secret.encode("utf-8")
+
+    return normalized
+
+
+def _encode_payload(payload: dict[str, object]) -> str:
+    payload_bytes = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(payload_bytes).decode("utf-8").rstrip("=")
+
+
+def _split_token(token: str) -> tuple[str, str]:
+    try:
+        payload_b64, signature_b64 = token.split(".", maxsplit=1)
+    except ValueError as exc:
+        raise InvalidTokenError("Malformed session token") from exc
+    return payload_b64, signature_b64
+
+
+def _decode_payload(payload_b64: str) -> dict[str, object]:
+    payload_bytes = _urlsafe_b64decode(payload_b64)
+    try:
+        payload = json.loads(payload_bytes.decode("utf-8"))
+    except (TypeError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise InvalidTokenError("Invalid token payload") from exc
+    if not isinstance(payload, dict):
+        raise InvalidTokenError("Invalid token payload")
+    return payload
+
+
+def _parse_key_id(payload: dict[str, object]) -> str:
+    key_id = _require_str(payload, "kid")
+    if not key_id:
+        raise InvalidTokenError("Invalid token payload")
+    return key_id
+
+
+def _require_int(payload: dict[str, object], key: str) -> int:
+    if key not in payload:
+        raise InvalidTokenError("Invalid token payload")
+    value = payload[key]
+    try:
+        if isinstance(value, int):
+            return value
+        if isinstance(value, (str, float)):
+            return int(value)
+        raise TypeError
+    except (TypeError, ValueError) as exc:
+        raise InvalidTokenError("Invalid token payload") from exc
+
+
+def _require_str(payload: dict[str, object], key: str) -> str:
+    if key not in payload:
+        raise InvalidTokenError("Invalid token payload")
+    value = payload[key]
+    try:
+        text = str(value)
+    except (TypeError, ValueError) as exc:
+        raise InvalidTokenError("Invalid token payload") from exc
+    if not text:
+        raise InvalidTokenError("Invalid token payload")
+    return text
 
 
 def _urlsafe_b64decode(value: str) -> bytes:

--- a/backend/api/tests/conftest.py
+++ b/backend/api/tests/conftest.py
@@ -14,6 +14,9 @@ from offload_backend.security import SessionClaims, TokenManager
 def test_env() -> Generator[None, None, None]:
     os.environ["OFFLOAD_SESSION_SECRET"] = "test-secret"
     os.environ["OFFLOAD_SESSION_TTL_SECONDS"] = "120"
+    os.environ["OFFLOAD_SESSION_TOKEN_ISSUER"] = "offload-backend-test"
+    os.environ["OFFLOAD_SESSION_TOKEN_AUDIENCE"] = "offload-ios-test"
+    os.environ["OFFLOAD_SESSION_TOKEN_ACTIVE_KID"] = "test-kid"
     os.environ["OFFLOAD_OPENAI_MODEL"] = "gpt-4o-mini"
     os.environ["OFFLOAD_MAX_INPUT_CHARS"] = "1000"
     os.environ["OFFLOAD_DEFAULT_FEATURE_QUOTA"] = "10"
@@ -48,7 +51,12 @@ def create_session_token(client: TestClient):
 @pytest.fixture
 def create_expired_session_token():
     def _create(install_id: str = "install-12345", secret: str = "test-secret") -> str:
-        manager = TokenManager(secret=secret)
+        manager = TokenManager(
+            secret=secret,
+            issuer=os.environ["OFFLOAD_SESSION_TOKEN_ISSUER"],
+            audience=os.environ["OFFLOAD_SESSION_TOKEN_AUDIENCE"],
+            active_kid=os.environ["OFFLOAD_SESSION_TOKEN_ACTIVE_KID"],
+        )
         expired_claims = SessionClaims(
             install_id=install_id,
             expires_at=datetime.now(UTC) - timedelta(seconds=1),

--- a/backend/api/tests/test_config.py
+++ b/backend/api/tests/test_config.py
@@ -50,3 +50,32 @@ def test_production_accepts_strong_explicit_session_secret(monkeypatch):
     settings = Settings()
 
     assert settings.session_secret == strong_secret
+
+
+def test_session_signing_keys_default_to_active_kid(monkeypatch):
+    monkeypatch.setenv("OFFLOAD_SESSION_SECRET", "test-secret")
+    monkeypatch.setenv("OFFLOAD_SESSION_TOKEN_ACTIVE_KID", "test-kid")
+    monkeypatch.delenv("OFFLOAD_SESSION_SIGNING_KEYS", raising=False)
+
+    settings = Settings()
+
+    assert settings.session_signing_keys == {"test-kid": "test-secret"}
+
+
+def test_rejects_active_kid_missing_from_signing_keys(monkeypatch):
+    monkeypatch.setenv("OFFLOAD_SESSION_TOKEN_ACTIVE_KID", "active-kid")
+    monkeypatch.setenv("OFFLOAD_SESSION_SIGNING_KEYS", '{"other-kid":"test-secret"}')
+
+    with pytest.raises(ValidationError, match="OFFLOAD_SESSION_TOKEN_ACTIVE_KID"):
+        Settings()
+
+
+def test_production_rejects_weak_signing_keys(monkeypatch):
+    strong_secret = "d4f0b11af3e742e5b006f9f98f4f9c2f-v1-rotatable"
+    monkeypatch.setenv("OFFLOAD_ENVIRONMENT", "production")
+    monkeypatch.setenv("OFFLOAD_SESSION_SECRET", strong_secret)
+    monkeypatch.setenv("OFFLOAD_SESSION_TOKEN_ACTIVE_KID", "test-kid")
+    monkeypatch.setenv("OFFLOAD_SESSION_SIGNING_KEYS", '{"test-kid":"test-secret"}')
+
+    with pytest.raises(ValidationError, match="OFFLOAD_SESSION_SIGNING_KEYS"):
+        Settings()

--- a/backend/api/tests/test_session_token_v2.py
+++ b/backend/api/tests/test_session_token_v2.py
@@ -1,0 +1,136 @@
+import base64
+import hashlib
+import hmac
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from offload_backend.security import ExpiredTokenError, SessionClaims, TokenManager
+
+REQUIRED_V2_CLAIMS = {"v", "kid", "iat", "nbf", "iss", "aud", "exp", "install_id"}
+
+
+def _urlsafe_b64encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("utf-8").rstrip("=")
+
+
+def _payload_from_token(token: str) -> dict[str, object]:
+    payload_segment = token.split(".", maxsplit=1)[0]
+    padding = "=" * (-len(payload_segment) % 4)
+    payload_bytes = base64.urlsafe_b64decode(f"{payload_segment}{padding}".encode())
+    return json.loads(payload_bytes.decode("utf-8"))
+
+
+def _build_signed_token(payload: dict[str, object], secret: str = "test-secret") -> str:
+    payload_segment = _urlsafe_b64encode(
+        json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+    )
+    signature = hmac.new(secret.encode("utf-8"), payload_segment.encode("utf-8"), hashlib.sha256)
+    return f"{payload_segment}.{_urlsafe_b64encode(signature.digest())}"
+
+
+class _ManualClock:
+    def __init__(self, start: datetime):
+        self._now = start
+
+    def now(self) -> datetime:
+        return self._now
+
+    def advance(self, *, seconds: int) -> None:
+        self._now += timedelta(seconds=seconds)
+
+
+def test_session_token_uses_v2_required_claims(create_session_token):
+    token = create_session_token()
+    payload = _payload_from_token(token)
+
+    assert REQUIRED_V2_CLAIMS.issubset(payload.keys())
+    assert payload["v"] == 2
+    assert payload["kid"] == "test-kid"
+    assert payload["iss"] == "offload-backend-test"
+    assert payload["aud"] == "offload-ios-test"
+
+
+@pytest.mark.parametrize(
+    ("claim", "value"),
+    [
+        ("iss", "wrong-issuer"),
+        ("aud", "wrong-audience"),
+        ("kid", "unknown-kid"),
+    ],
+)
+def test_token_decode_rejects_invalid_metadata_claims(
+    post_usage_reconcile,
+    claim: str,
+    value: str,
+):
+    now = datetime(2026, 2, 16, 12, 0, tzinfo=UTC)
+    payload = {
+        "v": 2,
+        "kid": "test-kid",
+        "iat": int(now.timestamp()),
+        "nbf": int(now.timestamp()),
+        "iss": "offload-backend-test",
+        "aud": "offload-ios-test",
+        "exp": int((now + timedelta(seconds=300)).timestamp()),
+        "install_id": "install-12345",
+    }
+    payload[claim] = value
+    token = _build_signed_token(payload, secret="test-secret")
+
+    response = post_usage_reconcile(authorization=f"Bearer {token}")
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "invalid_token"
+
+
+def test_legacy_v1_token_is_rejected(post_usage_reconcile):
+    legacy_payload = {
+        "install_id": "install-12345",
+        "exp": int((datetime.now(UTC) + timedelta(seconds=300)).timestamp()),
+    }
+    token = _build_signed_token(legacy_payload, secret="test-secret")
+
+    response = post_usage_reconcile(authorization=f"Bearer {token}")
+
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "invalid_token"
+
+
+def test_token_manager_issue_session_uses_injected_clock():
+    clock = _ManualClock(start=datetime(2026, 2, 16, 12, 0, tzinfo=UTC))
+    manager = TokenManager(
+        secret="test-secret",
+        issuer="offload-backend-test",
+        audience="offload-ios-test",
+        active_kid="test-kid",
+        now_provider=clock.now,
+    )
+
+    claims = manager.issue_session(install_id="install-12345", ttl_seconds=120)
+
+    assert claims == SessionClaims(
+        install_id="install-12345",
+        expires_at=datetime(2026, 2, 16, 12, 2, tzinfo=UTC),
+    )
+
+
+def test_token_manager_decode_uses_injected_clock_for_expiry():
+    clock = _ManualClock(start=datetime(2026, 2, 16, 12, 0, tzinfo=UTC))
+    manager = TokenManager(
+        secret="test-secret",
+        issuer="offload-backend-test",
+        audience="offload-ios-test",
+        active_kid="test-kid",
+        now_provider=clock.now,
+    )
+
+    claims = SessionClaims(
+        install_id="install-12345",
+        expires_at=datetime(2026, 2, 16, 12, 0, 1, tzinfo=UTC),
+    )
+    token = manager.encode(claims)
+
+    clock.advance(seconds=2)
+    with pytest.raises(ExpiredTokenError):
+        manager.decode(token)

--- a/docs/plans/plan-backend-session-security-hardening.md
+++ b/docs/plans/plan-backend-session-security-hardening.md
@@ -84,21 +84,21 @@ issuance, and token metadata/version upgrades for key rotation readiness.
 
 ### Phase 4: Token V2 Claims and Key Metadata (Hard Cutover)
 
-**Status:** Not Started
+**Status:** Completed
 
-- [ ] Red:
-  - [ ] Add tests requiring claims: `v`, `kid`, `iat`, `nbf`, `iss`, `aud`,
+- [x] Red:
+  - [x] Add tests requiring claims: `v`, `kid`, `iat`, `nbf`, `iss`, `aud`,
         `exp`, `install_id`.
-  - [ ] Add tests requiring strict issuer/audience/key-id validation.
-  - [ ] Add tests verifying v1 tokens are rejected after cutover.
-- [ ] Green:
-  - [ ] Implement token v2 encode/decode with key-id aware signing and
+  - [x] Add tests requiring strict issuer/audience/key-id validation.
+  - [x] Add tests verifying v1 tokens are rejected after cutover.
+- [x] Green:
+  - [x] Implement token v2 encode/decode with key-id aware signing and
         constant-time signature checks.
-  - [ ] Add token configuration for issuer, audience, active key ID, and key
+  - [x] Add token configuration for issuer, audience, active key ID, and key
         material.
-- [ ] Refactor:
-  - [ ] Inject deterministic clock for tests.
-  - [ ] Consolidate claim parsing and validation error mapping.
+- [x] Refactor:
+  - [x] Inject deterministic clock for tests.
+  - [x] Consolidate claim parsing and validation error mapping.
 
 ## Dependencies
 
@@ -127,3 +127,4 @@ issuance, and token metadata/version upgrades for key rotation readiness.
 | --- | --- |
 | 2026-02-16 | Plan created from CODE_REVIEW_2026-02-15 security findings split. |
 | 2026-02-16 | Completed Phases 1-3: auth regression lock, production secret policy enforcement, and session issuance rate limiting with deterministic 429/reset behavior and bounded telemetry. |
+| 2026-02-16 | Completed Phase 4 hard cutover to token v2 claims (`v`,`kid`,`iat`,`nbf`,`iss`,`aud`,`exp`,`install_id`) with strict metadata validation, v1 rejection, deterministic clock tests, and key-id-aware signing config. |


### PR DESCRIPTION
## Summary
- hard-cut over backend session tokens to v2 claims with required metadata (`v`, `kid`, `iat`, `nbf`, `iss`, `aud`, `exp`, `install_id`)
- enforce strict issuer/audience/key-id validation and reject legacy v1 tokens
- add key-id-aware signing key configuration and validation for rotation readiness
- inject deterministic token clock support for reliable time-based tests
- add Phase 4 regression tests and update backend session security plan progress

## Testing
- `uv run --project backend/api --extra dev ruff check backend/api/src backend/api/tests`
- `uv run --project backend/api --extra dev ty check src tests` (from `backend/api`)
- `uv run --project backend/api --extra dev pytest backend/api/tests -q`
