### PR TITLE
feat(backend): reliability and durability hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ just ios-test-ci              # Run iOS CI-style test lane locally
 just backend-install-uv       # Sync backend dev dependencies with uv
 just backend-check            # Run backend ruff + ty + pytest
 just backend-test-coverage    # Run backend tests with coverage summary
+just backend-check-coverage   # Run backend lint + typecheck + coverage tests
+just backend-clean            # Remove generated backend runtime/build artifacts
 just backend-check-ci         # Run backend CI script locally
 just ci-local                 # Run lint + backend checks + iOS tests
 
@@ -108,6 +110,11 @@ just ci-local                 # Run lint + backend checks + iOS tests
   YAML front-matter per `docs/AGENTS.md`
 - Prioritize using `just` for common commands and keep the `justfile` at project root up to date
 - For backend changes: run `just backend-check` (or `just backend-check-ci`) before opening/updating PRs
+- For backend persistence, security, or provider-resilience changes: run
+  `just backend-check-coverage` before opening/updating PRs
+- Never commit generated backend runtime/build artifacts (`.offload-backend/`,
+  `backend/api/.offload-backend/`, `backend/api/src/offload_backend_api.egg-info/`);
+  use `just backend-clean` when needed
 - For UI work: use `Theme.*` tokens (no hardcoded colors/spacing/radii/fonts)
   and reuse `ios/Offload/DesignSystem/Components.swift` before creating new
   UI primitives

--- a/backend/api/src/offload_backend/dependencies.py
+++ b/backend/api/src/offload_backend/dependencies.py
@@ -21,7 +21,7 @@ from offload_backend.session_rate_limiter import (
     SessionRateLimiter,
     SessionRateLimitExceeded,
 )
-from offload_backend.usage_store import InMemoryUsageStore
+from offload_backend.usage_store import UsageStore
 
 bearer_scheme = HTTPBearer(auto_error=False)
 logger = logging.getLogger("offload_backend")
@@ -83,7 +83,7 @@ def get_provider(settings: Settings = Depends(get_app_settings)) -> AIProvider:
     return OpenAIProviderAdapter(settings=settings)
 
 
-def get_usage_store(request: Request) -> InMemoryUsageStore:
+def get_usage_store(request: Request) -> UsageStore:
     return request.app.state.usage_store
 
 

--- a/backend/api/src/offload_backend/providers/openai_adapter.py
+++ b/backend/api/src/offload_backend/providers/openai_adapter.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
+import random
+from collections.abc import Awaitable, Callable
 
 import httpx
 
@@ -13,12 +17,26 @@ from offload_backend.providers.base import (
     ProviderUnavailable,
 )
 
+logger = logging.getLogger("offload_backend")
+RequestExecutor = Callable[[str, dict, dict, httpx.Timeout], Awaitable[httpx.Response]]
+SleepFunction = Callable[[float], Awaitable[None]]
+
 
 class OpenAIProviderAdapter:
     provider_name = "openai"
 
-    def __init__(self, settings: Settings):
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        request_executor: RequestExecutor | None = None,
+        sleep_fn: SleepFunction = asyncio.sleep,
+        random_fn: Callable[[], float] = random.random,
+    ):
         self._settings = settings
+        self._request_executor = request_executor or self._default_request_executor
+        self._sleep_fn = sleep_fn
+        self._random_fn = random_fn
 
     async def generate_breakdown(
         self,
@@ -31,7 +49,74 @@ class OpenAIProviderAdapter:
         if not self._settings.openai_api_key:
             raise ProviderUnavailable("OpenAI API key is not configured")
 
-        payload = {
+        payload = self._request_payload(
+            input_text=input_text,
+            granularity=granularity,
+            context_hints=context_hints,
+            template_ids=template_ids,
+        )
+        headers = {
+            "Authorization": f"Bearer {self._settings.openai_api_key}",
+            "Content-Type": "application/json",
+        }
+        url = f"{self._settings.openai_base_url}/chat/completions"
+        timeout = httpx.Timeout(self._settings.openai_timeout_seconds)
+
+        total_delay_slept = 0.0
+        max_attempts = self._settings.openai_retry_max_attempts
+        last_retryable_error: Exception | None = None
+
+        for attempt in range(1, max_attempts + 1):
+            try:
+                response = await self._request_executor(url, payload, headers, timeout)
+            except httpx.TimeoutException:
+                last_retryable_error = ProviderTimeout("OpenAI request timed out")
+            except httpx.HTTPError:
+                last_retryable_error = ProviderRequestError("OpenAI request failed")
+            else:
+                if response.status_code >= 500:
+                    last_retryable_error = ProviderRequestError("OpenAI server error")
+                elif response.status_code == 429:
+                    last_retryable_error = ProviderRequestError("OpenAI rate limited")
+                elif response.status_code >= 400:
+                    raise ProviderRequestError("OpenAI request rejected")
+                else:
+                    result = self._parse_success_response(response)
+                    if attempt > 1:
+                        logger.info(
+                            "provider_retry_recovered",
+                            extra={"attempt_count": attempt, "provider": self.provider_name},
+                        )
+                    return result
+
+            assert last_retryable_error is not None
+            if attempt >= max_attempts:
+                break
+            delay = self._retry_delay(attempt=attempt, total_delay_slept=total_delay_slept)
+            total_delay_slept += delay
+            if delay > 0:
+                await self._sleep_fn(delay)
+
+        assert last_retryable_error is not None
+        logger.warning(
+            "provider_retry_terminal",
+            extra={
+                "attempt_count": max_attempts,
+                "error_class": last_retryable_error.__class__.__name__,
+                "provider": self.provider_name,
+            },
+        )
+        raise last_retryable_error
+
+    def _request_payload(
+        self,
+        *,
+        input_text: str,
+        granularity: int,
+        context_hints: list[str],
+        template_ids: list[str],
+    ) -> dict:
+        return {
             "model": self._settings.openai_model,
             "messages": [
                 {
@@ -57,30 +142,29 @@ class OpenAIProviderAdapter:
             "response_format": {"type": "json_object"},
         }
 
-        headers = {
-            "Authorization": f"Bearer {self._settings.openai_api_key}",
-            "Content-Type": "application/json",
-        }
+    async def _default_request_executor(
+        self,
+        url: str,
+        payload: dict,
+        headers: dict,
+        timeout: httpx.Timeout,
+    ) -> httpx.Response:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            return await client.post(url, json=payload, headers=headers)
 
-        timeout = httpx.Timeout(self._settings.openai_timeout_seconds)
+    def _retry_delay(self, *, attempt: int, total_delay_slept: float) -> float:
+        base = self._settings.openai_retry_base_delay_seconds
+        max_delay = self._settings.openai_retry_max_delay_seconds
+        bounded_base = min(max_delay, base * (2 ** (attempt - 1)))
+        jitter = bounded_base * self._settings.openai_retry_jitter_factor * self._random_fn()
+        candidate = min(max_delay, bounded_base + jitter)
+        budget_left = max(
+            0.0,
+            self._settings.openai_retry_max_total_delay_seconds - total_delay_slept,
+        )
+        return min(candidate, budget_left)
 
-        try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
-                response = await client.post(
-                    f"{self._settings.openai_base_url}/chat/completions",
-                    json=payload,
-                    headers=headers,
-                )
-        except httpx.TimeoutException as exc:
-            raise ProviderTimeout("OpenAI request timed out") from exc
-        except httpx.HTTPError as exc:
-            raise ProviderRequestError("OpenAI request failed") from exc
-
-        if response.status_code >= 500:
-            raise ProviderRequestError("OpenAI server error")
-        if response.status_code >= 400:
-            raise ProviderRequestError("OpenAI request rejected")
-
+    def _parse_success_response(self, response: httpx.Response) -> ProviderBreakdownResult:
         try:
             body = response.json()
             content = body["choices"][0]["message"]["content"]

--- a/backend/api/src/offload_backend/routers/usage.py
+++ b/backend/api/src/offload_backend/routers/usage.py
@@ -9,7 +9,7 @@ from offload_backend.dependencies import get_app_settings, get_session_claims, g
 from offload_backend.errors import APIException
 from offload_backend.schemas import UsageReconcileRequest, UsageReconcileResponse
 from offload_backend.security import SessionClaims
-from offload_backend.usage_store import InMemoryUsageStore
+from offload_backend.usage_store import UsageStore
 
 router = APIRouter()
 
@@ -18,7 +18,7 @@ router = APIRouter()
 def reconcile_usage(
     request: UsageReconcileRequest,
     claims: SessionClaims = Depends(get_session_claims),
-    usage_store: InMemoryUsageStore = Depends(get_usage_store),
+    usage_store: UsageStore = Depends(get_usage_store),
     settings: Settings = Depends(get_app_settings),
 ) -> UsageReconcileResponse:
     if claims.install_id != request.install_id:

--- a/backend/api/src/offload_backend/usage_store.py
+++ b/backend/api/src/offload_backend/usage_store.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
+import sqlite3
+from pathlib import Path
 from threading import Lock
+from typing import Protocol
+
+
+class UsageStore(Protocol):
+    def reconcile(self, *, install_id: str, feature: str, local_count: int) -> int: ...
+    def dump(self) -> dict[tuple[str, str], int]: ...
+    def close(self) -> None: ...
 
 
 class InMemoryUsageStore:
@@ -19,3 +28,84 @@ class InMemoryUsageStore:
     def dump(self) -> dict[tuple[str, str], int]:
         with self._lock:
             return dict(self._counts)
+
+    def close(self) -> None:
+        return None
+
+
+class SQLiteUsageStore:
+    def __init__(self, *, db_path: str):
+        self._lock = Lock()
+        self._connection = self._open_connection(db_path=db_path)
+        self._bootstrap_schema()
+
+    def _open_connection(self, *, db_path: str) -> sqlite3.Connection:
+        if db_path != ":memory:":
+            Path(db_path).expanduser().resolve().parent.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(db_path, check_same_thread=False)
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("PRAGMA busy_timeout=5000")
+        return connection
+
+    def _bootstrap_schema(self) -> None:
+        with self._lock:
+            self._connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS usage_counts (
+                    install_id TEXT NOT NULL,
+                    feature TEXT NOT NULL,
+                    count INTEGER NOT NULL,
+                    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (install_id, feature)
+                )
+                """,
+            )
+            self._connection.commit()
+
+    def _reconcile_transaction(self, *, install_id: str, feature: str, local_count: int) -> int:
+        self._connection.execute("BEGIN IMMEDIATE")
+        self._connection.execute(
+            """
+            INSERT INTO usage_counts (install_id, feature, count)
+            VALUES (?, ?, ?)
+            ON CONFLICT (install_id, feature)
+            DO UPDATE SET
+                count = MAX(usage_counts.count, excluded.count),
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (install_id, feature, local_count),
+        )
+        row = self._connection.execute(
+            "SELECT count FROM usage_counts WHERE install_id = ? AND feature = ?",
+            (install_id, feature),
+        ).fetchone()
+        self._connection.commit()
+        if row is None:
+            raise RuntimeError("failed to reconcile usage count")
+        return int(row[0])
+
+    def reconcile(self, *, install_id: str, feature: str, local_count: int) -> int:
+        with self._lock:
+            try:
+                return self._reconcile_transaction(
+                    install_id=install_id,
+                    feature=feature,
+                    local_count=local_count,
+                )
+            except Exception:
+                self._connection.rollback()
+                raise
+
+    def dump(self) -> dict[tuple[str, str], int]:
+        with self._lock:
+            rows = self._connection.execute(
+                "SELECT install_id, feature, count FROM usage_counts",
+            ).fetchall()
+            return {
+                (str(install_id), str(feature)): int(count)
+                for install_id, feature, count in rows
+            }
+
+    def close(self) -> None:
+        with self._lock:
+            self._connection.close()

--- a/backend/api/tests/test_breakdown.py
+++ b/backend/api/tests/test_breakdown.py
@@ -33,18 +33,13 @@ class FailureProvider:
         raise ProviderRequestError("provider failure")
 
 
-def test_breakdown_generation_success(client, app, create_session_token):
+def test_breakdown_generation_success(client, app, create_session_token, make_breakdown_payload):
     app.dependency_overrides[get_provider] = lambda: FakeProvider()
     token = create_session_token()
 
     response = client.post(
         "/v1/ai/breakdown/generate",
-        json={
-            "input_text": "Clean the kitchen",
-            "granularity": 3,
-            "context_hints": ["home"],
-            "template_ids": ["template-1"],
-        },
+        json=make_breakdown_payload(context_hints=["home"], template_ids=["template-1"]),
         headers={
             "Authorization": f"Bearer {token}",
             "X-Offload-Cloud-Opt-In": "true",
@@ -60,13 +55,18 @@ def test_breakdown_generation_success(client, app, create_session_token):
     app.dependency_overrides.clear()
 
 
-def test_breakdown_rejects_missing_opt_in(client, app, create_session_token):
+def test_breakdown_rejects_missing_opt_in(
+    client,
+    app,
+    create_session_token,
+    make_breakdown_payload,
+):
     app.dependency_overrides[get_provider] = lambda: FakeProvider()
     token = create_session_token()
 
     response = client.post(
         "/v1/ai/breakdown/generate",
-        json={"input_text": "Clean the kitchen", "granularity": 3},
+        json=make_breakdown_payload(),
         headers={"Authorization": f"Bearer {token}"},
     )
 
@@ -76,13 +76,13 @@ def test_breakdown_rejects_missing_opt_in(client, app, create_session_token):
     app.dependency_overrides.clear()
 
 
-def test_breakdown_schema_validation(client, app, create_session_token):
+def test_breakdown_schema_validation(client, app, create_session_token, make_breakdown_payload):
     app.dependency_overrides[get_provider] = lambda: FakeProvider()
     token = create_session_token()
 
     response = client.post(
         "/v1/ai/breakdown/generate",
-        json={"input_text": "x", "granularity": 7},
+        json=make_breakdown_payload(input_text="x", granularity=7),
         headers={
             "Authorization": f"Bearer {token}",
             "X-Offload-Cloud-Opt-In": "true",
@@ -114,6 +114,101 @@ def test_breakdown_provider_timeout_mapping(client, app, create_session_token):
     app.dependency_overrides.clear()
 
 
+def test_breakdown_accepts_list_field_length_boundary(
+    client,
+    app,
+    create_session_token,
+    make_breakdown_payload,
+):
+    app.dependency_overrides[get_provider] = lambda: FakeProvider()
+    token = create_session_token()
+
+    response = client.post(
+        "/v1/ai/breakdown/generate",
+        json=make_breakdown_payload(
+            input_text="x",
+            context_hints=["h"] * 32,
+            template_ids=["t"] * 32,
+        ),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "X-Offload-Cloud-Opt-In": "true",
+        },
+    )
+
+    assert response.status_code == 200
+    app.dependency_overrides.clear()
+
+
+def test_breakdown_rejects_list_field_length_over_limit(
+    client,
+    app,
+    create_session_token,
+    make_breakdown_payload,
+):
+    app.dependency_overrides[get_provider] = lambda: FakeProvider()
+    token = create_session_token()
+
+    response = client.post(
+        "/v1/ai/breakdown/generate",
+        json=make_breakdown_payload(context_hints=["h"] * 33),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "X-Offload-Cloud-Opt-In": "true",
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "validation_error"
+    app.dependency_overrides.clear()
+
+
+def test_breakdown_rejects_context_hint_element_too_long(
+    client,
+    app,
+    create_session_token,
+    make_breakdown_payload,
+):
+    app.dependency_overrides[get_provider] = lambda: FakeProvider()
+    token = create_session_token()
+
+    response = client.post(
+        "/v1/ai/breakdown/generate",
+        json=make_breakdown_payload(context_hints=["x" * 281]),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "X-Offload-Cloud-Opt-In": "true",
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "validation_error"
+    app.dependency_overrides.clear()
+
+
+def test_breakdown_rejects_template_id_element_too_long(
+    client,
+    app,
+    create_session_token,
+    make_breakdown_payload,
+):
+    app.dependency_overrides[get_provider] = lambda: FakeProvider()
+    token = create_session_token()
+
+    response = client.post(
+        "/v1/ai/breakdown/generate",
+        json=make_breakdown_payload(template_ids=["x" * 129]),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "X-Offload-Cloud-Opt-In": "true",
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "validation_error"
+    app.dependency_overrides.clear()
+
+
 def test_breakdown_provider_failure_mapping(client, app, create_session_token):
     app.dependency_overrides[get_provider] = lambda: FailureProvider()
     token = create_session_token()
@@ -133,13 +228,18 @@ def test_breakdown_provider_failure_mapping(client, app, create_session_token):
     app.dependency_overrides.clear()
 
 
-def test_breakdown_request_limit_enforced(client, app, create_session_token):
+def test_breakdown_request_limit_enforced(
+    client,
+    app,
+    create_session_token,
+    make_breakdown_payload,
+):
     app.dependency_overrides[get_provider] = lambda: FakeProvider()
     token = create_session_token()
 
     response = client.post(
         "/v1/ai/breakdown/generate",
-        json={"input_text": "x" * 1200, "granularity": 2},
+        json=make_breakdown_payload(input_text="x" * 1200, granularity=2),
         headers={
             "Authorization": f"Bearer {token}",
             "X-Offload-Cloud-Opt-In": "true",
@@ -156,18 +256,19 @@ def test_breakdown_request_limit_counts_context_hints_and_template_ids(
     client,
     app,
     create_session_token,
+    make_breakdown_payload,
 ):
     app.dependency_overrides[get_provider] = lambda: FakeProvider()
     token = create_session_token()
 
     response = client.post(
         "/v1/ai/breakdown/generate",
-        json={
-            "input_text": "x",
-            "granularity": 2,
-            "context_hints": ["a" * 280, "b" * 280, "c" * 280, "d" * 280],
-            "template_ids": [],
-        },
+        json=make_breakdown_payload(
+            input_text="x",
+            granularity=2,
+            context_hints=["a" * 280, "b" * 280, "c" * 280],
+            template_ids=["d" * 128, "e" * 128],
+        ),
         headers={
             "Authorization": f"Bearer {token}",
             "X-Offload-Cloud-Opt-In": "true",
@@ -180,14 +281,19 @@ def test_breakdown_request_limit_counts_context_hints_and_template_ids(
     app.dependency_overrides.clear()
 
 
-def test_breakdown_does_not_persist_prompt_content(client, app, create_session_token):
+def test_breakdown_does_not_persist_prompt_content(
+    client,
+    app,
+    create_session_token,
+    make_breakdown_payload,
+):
     app.dependency_overrides[get_provider] = lambda: FakeProvider()
     token = create_session_token()
     prompt = "super-private-prompt-content"
 
     response = client.post(
         "/v1/ai/breakdown/generate",
-        json={"input_text": prompt, "granularity": 3},
+        json=make_breakdown_payload(input_text=prompt),
         headers={
             "Authorization": f"Bearer {token}",
             "X-Offload-Cloud-Opt-In": "true",

--- a/backend/api/tests/test_openai_retry.py
+++ b/backend/api/tests/test_openai_retry.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from offload_backend.config import Settings
+from offload_backend.providers.base import ProviderRequestError
+from offload_backend.providers.openai_adapter import OpenAIProviderAdapter
+
+
+def _response(status_code: int, payload: dict) -> httpx.Response:
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    return httpx.Response(status_code=status_code, json=payload, request=request)
+
+
+def _settings(
+    *,
+    openai_retry_max_attempts: int = 3,
+    openai_retry_base_delay_seconds: float = 0.5,
+    openai_retry_max_delay_seconds: float = 2.0,
+    openai_retry_max_total_delay_seconds: float = 3.0,
+    openai_retry_jitter_factor: float = 0.0,
+) -> Settings:
+    return Settings(
+        session_secret="test-secret",
+        openai_api_key="test-key",
+        openai_retry_max_attempts=openai_retry_max_attempts,
+        openai_retry_base_delay_seconds=openai_retry_base_delay_seconds,
+        openai_retry_max_delay_seconds=openai_retry_max_delay_seconds,
+        openai_retry_max_total_delay_seconds=openai_retry_max_total_delay_seconds,
+        openai_retry_jitter_factor=openai_retry_jitter_factor,
+    )
+
+
+def test_openai_adapter_retries_timeout_then_succeeds():
+    attempts = {"count": 0}
+    slept: list[float] = []
+
+    async def fake_sleep(delay: float):
+        slept.append(delay)
+
+    async def fake_executor(url, payload, headers, timeout):
+        _ = (url, payload, headers, timeout)
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise httpx.ReadTimeout("timed out")
+        return _response(
+            200,
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": '{"steps":[{"title":"Step 1","substeps":[]}]}',
+                        },
+                    }
+                ],
+                "usage": {"prompt_tokens": 11, "completion_tokens": 7},
+            },
+        )
+
+    adapter = OpenAIProviderAdapter(
+        settings=_settings(),
+        request_executor=fake_executor,
+        sleep_fn=fake_sleep,
+    )
+
+    result = asyncio.run(
+        adapter.generate_breakdown(
+            input_text="clean kitchen",
+            granularity=2,
+            context_hints=[],
+            template_ids=[],
+        ),
+    )
+
+    assert attempts["count"] == 2
+    assert len(slept) == 1
+    assert result.input_tokens == 11
+    assert result.output_tokens == 7
+
+
+def test_openai_adapter_does_not_retry_non_retriable_4xx():
+    attempts = {"count": 0}
+    slept: list[float] = []
+
+    async def fake_sleep(delay: float):
+        slept.append(delay)
+
+    async def fake_executor(url, payload, headers, timeout):
+        _ = (url, payload, headers, timeout)
+        attempts["count"] += 1
+        return _response(400, {"error": {"message": "bad request"}})
+
+    adapter = OpenAIProviderAdapter(
+        settings=_settings(),
+        request_executor=fake_executor,
+        sleep_fn=fake_sleep,
+    )
+
+    with pytest.raises(ProviderRequestError, match="rejected"):
+        asyncio.run(
+            adapter.generate_breakdown(
+                input_text="clean kitchen",
+                granularity=2,
+                context_hints=[],
+                template_ids=[],
+            ),
+        )
+
+    assert attempts["count"] == 1
+    assert slept == []
+
+
+def test_openai_adapter_retries_429_and_5xx_with_bounded_attempts(caplog):
+    attempts = {"count": 0}
+    slept: list[float] = []
+
+    async def fake_sleep(delay: float):
+        slept.append(delay)
+
+    async def fake_executor(url, payload, headers, timeout):
+        _ = (url, payload, headers, timeout)
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            return _response(429, {"error": {"message": "rate limited"}})
+        return _response(503, {"error": {"message": "unavailable"}})
+
+    adapter = OpenAIProviderAdapter(
+        settings=_settings(openai_retry_max_attempts=3),
+        request_executor=fake_executor,
+        sleep_fn=fake_sleep,
+    )
+
+    with caplog.at_level("WARNING", logger="offload_backend"):
+        with pytest.raises(ProviderRequestError, match="server error"):
+            asyncio.run(
+                adapter.generate_breakdown(
+                    input_text="clean kitchen",
+                    granularity=2,
+                    context_hints=[],
+                    template_ids=[],
+                ),
+            )
+
+    assert attempts["count"] == 3
+    assert len(slept) == 2
+    terminal = [record for record in caplog.records if record.msg == "provider_retry_terminal"]
+    assert terminal
+    assert terminal[-1].attempt_count == 3
+    assert terminal[-1].error_class == "ProviderRequestError"
+
+
+def test_openai_adapter_bounds_total_retry_delay_budget():
+    attempts = {"count": 0}
+    slept: list[float] = []
+
+    async def fake_sleep(delay: float):
+        slept.append(delay)
+
+    async def fake_executor(url, payload, headers, timeout):
+        _ = (url, payload, headers, timeout)
+        attempts["count"] += 1
+        return _response(503, {"error": {"message": "unavailable"}})
+
+    adapter = OpenAIProviderAdapter(
+        settings=_settings(
+            openai_retry_max_attempts=5,
+            openai_retry_base_delay_seconds=1.0,
+            openai_retry_max_delay_seconds=10.0,
+            openai_retry_max_total_delay_seconds=1.5,
+        ),
+        request_executor=fake_executor,
+        sleep_fn=fake_sleep,
+    )
+
+    with pytest.raises(ProviderRequestError):
+        asyncio.run(
+            adapter.generate_breakdown(
+                input_text="clean kitchen",
+                granularity=2,
+                context_hints=[],
+                template_ids=[],
+            ),
+        )
+
+    assert attempts["count"] == 5
+    assert sum(slept) <= 1.5

--- a/backend/api/tests/test_usage.py
+++ b/backend/api/tests/test_usage.py
@@ -1,3 +1,10 @@
+from offload_backend.usage_store import SQLiteUsageStore
+
+
+def test_usage_store_defaults_to_sqlite(app):
+    assert isinstance(app.state.usage_store, SQLiteUsageStore)
+
+
 def test_reconcile_uses_authoritative_max(create_session_token, post_usage_reconcile):
     token = create_session_token()
 

--- a/backend/api/tests/test_usage_store.py
+++ b/backend/api/tests/test_usage_store.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+from offload_backend.usage_store import SQLiteUsageStore
+
+
+def test_sqlite_usage_store_persists_across_restart(tmp_path):
+    db_path = tmp_path / "usage.sqlite3"
+
+    first_store = SQLiteUsageStore(db_path=str(db_path))
+    first = first_store.reconcile(install_id="install-1", feature="breakdown", local_count=4)
+    assert first == 4
+    first_store.close()
+
+    second_store = SQLiteUsageStore(db_path=str(db_path))
+    second = second_store.reconcile(install_id="install-1", feature="breakdown", local_count=2)
+    assert second == 4
+    assert second_store.dump() == {("install-1", "breakdown"): 4}
+    second_store.close()
+
+
+def test_sqlite_usage_store_reconcile_is_atomic_under_concurrency(tmp_path):
+    db_path = tmp_path / "usage.sqlite3"
+    store_a = SQLiteUsageStore(db_path=str(db_path))
+    store_b = SQLiteUsageStore(db_path=str(db_path))
+
+    def _reconcile(local_count: int):
+        target = store_a if local_count % 2 == 0 else store_b
+        return target.reconcile(
+            install_id="install-1",
+            feature="breakdown",
+            local_count=local_count,
+        )
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        list(pool.map(_reconcile, range(0, 50)))
+
+    final_count = store_a.reconcile(install_id="install-1", feature="breakdown", local_count=0)
+    assert final_count == 49
+
+    store_a.close()
+    store_b.close()

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -90,10 +90,10 @@ proposed → accepted → in-progress → completed/archived
 - [Plan: Fix Collection Position Backfill](./plan-fix-collection-position-backfill.md)
 - [Plan: Backend API + Privacy Constraints MVP (Breakdown-First)](./plan-backend-api-privacy.md)
 - [Plan: Backend Session Security Hardening](./plan-backend-session-security-hardening.md)
+- [Plan: Backend Reliability and Durability Hardening](./plan-backend-reliability-durability.md)
 
 ### Proposed
 
-- [Plan: Backend Reliability and Durability Hardening](./plan-backend-reliability-durability.md)
 - [Plan: iOS Data and Performance Hardening](./plan-ios-data-performance-hardening.md)
 - [Plan: Tab Shell Accessibility Hardening](./plan-tab-shell-accessibility-hardening.md)
 - [Plan: Visual Timeline (Pending Confirmation)](./plan-visual-timeline.md)

--- a/docs/plans/plan-backend-reliability-durability.md
+++ b/docs/plans/plan-backend-reliability-durability.md
@@ -1,7 +1,7 @@
 ---
 id: plan-backend-reliability-durability
 type: plan
-status: proposed
+status: in-progress
 owners:
   - Will-Conklin
 applies_to:
@@ -44,48 +44,48 @@ explicit regression verification for already-fixed payload guardrails.
 
 ### Phase 1: Guardrail Verification Lock (Already Fixed)
 
-**Status:** Not Started
+**Status:** Completed
 
-- [ ] Red:
-  - [ ] Add boundary tests for `context_hints`/`template_ids` list lengths and
+- [x] Red:
+  - [x] Add boundary tests for `context_hints`/`template_ids` list lengths and
         per-element max lengths.
-  - [ ] Add tests proving aggregate request size rejects oversized combined
+  - [x] Add tests proving aggregate request size rejects oversized combined
         payloads.
-- [ ] Green: keep existing schema/router enforcement intact while adding any
+- [x] Green: keep existing schema/router enforcement intact while adding any
       missing assertions.
-- [ ] Refactor: consolidate breakdown request fixture builders.
+- [x] Refactor: consolidate breakdown request fixture builders.
 
 ### Phase 2: Durable Usage Store (SQLite First)
 
-**Status:** Not Started
+**Status:** Completed
 
-- [ ] Red:
-  - [ ] Add usage-store contract tests for persistence across app restart.
-  - [ ] Add concurrency tests verifying atomic `max(local, server)` upsert
+- [x] Red:
+  - [x] Add usage-store contract tests for persistence across app restart.
+  - [x] Add concurrency tests verifying atomic `max(local, server)` upsert
         semantics.
-- [ ] Green:
-  - [ ] Introduce usage store protocol and SQLite implementation.
-  - [ ] Wire app dependencies to use SQLite store by default.
-  - [ ] Preserve API response shape for `/v1/usage/reconcile`.
-- [ ] Refactor:
-  - [ ] Separate schema/bootstrap from reconcile operations.
-  - [ ] Add deterministic test database setup helpers.
+- [x] Green:
+  - [x] Introduce usage store protocol and SQLite implementation.
+  - [x] Wire app dependencies to use SQLite store by default.
+  - [x] Preserve API response shape for `/v1/usage/reconcile`.
+- [x] Refactor:
+  - [x] Separate schema/bootstrap from reconcile operations.
+  - [x] Add deterministic test database setup helpers.
 
 ### Phase 3: Provider Retry and Backoff
 
-**Status:** Not Started
+**Status:** Completed
 
-- [ ] Red:
-  - [ ] Add adapter tests for retries on timeout/429/5xx and no-retry behavior
+- [x] Red:
+  - [x] Add adapter tests for retries on timeout/429/5xx and no-retry behavior
         on non-retriable 4xx.
-  - [ ] Add tests that bound max attempts and total delay.
-- [ ] Green:
-  - [ ] Implement bounded exponential backoff with jitter for transient
+  - [x] Add tests that bound max attempts and total delay.
+- [x] Green:
+  - [x] Implement bounded exponential backoff with jitter for transient
         provider errors.
-  - [ ] Add telemetry tags for attempt count and terminal error class.
-- [ ] Refactor:
-  - [ ] Extract retry policy into reusable configuration.
-  - [ ] Keep provider error mapping stable at router boundary.
+  - [x] Add telemetry tags for attempt count and terminal error class.
+- [x] Refactor:
+  - [x] Extract retry policy into reusable configuration.
+  - [x] Keep provider error mapping stable at router boundary.
 
 ## Dependencies
 
@@ -113,3 +113,4 @@ explicit regression verification for already-fixed payload guardrails.
 | Date | Update |
 | --- | --- |
 | 2026-02-16 | Plan created from CODE_REVIEW_2026-02-15 reliability/performance backend findings split. |
+| 2026-02-16 | Completed Phases 1-3: guardrail boundary regression lock, SQLite-backed durable reconcile store with concurrency coverage, and bounded provider retry/backoff with terminal telemetry tags. |

--- a/justfile
+++ b/justfile
@@ -35,10 +35,15 @@ backend-test:
 backend-test-coverage:
     python3 -m pytest backend/api/tests -q --cov=offload_backend --cov-report=term-missing:skip-covered
 
+backend-check-coverage: backend-lint backend-typecheck backend-test-coverage
+
 backend-typecheck:
     python3 -m ty check backend/api/src backend/api/tests
 
 backend-check: backend-lint backend-typecheck backend-test
+
+backend-clean:
+    rm -rf .offload-backend backend/api/.offload-backend backend/api/src/offload_backend_api.egg-info
 
 backend-check-ci:
     bash scripts/ci/backend-checks.sh


### PR DESCRIPTION
## Summary
- replace in-memory usage reconciliation with a SQLite-backed usage store and shared `UsageStore` protocol
- add durable usage store tests for restart persistence and concurrent atomic `max(local, server)` semantics
- implement bounded retry/backoff in the OpenAI adapter for timeout/429/5xx with terminal retry telemetry tags
- expand breakdown guardrail regression coverage for list boundaries, element limits, and aggregate request sizing
- update plan/docs and workflow guidance (`docs/plans`, `justfile`, `AGENTS.md`, `CLAUDE.md`)

Closes #190.

## Testing
- `just lint`
- `just backend-check`
