### PR TITLE
feat: harden tab shell accessibility policies

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -6,7 +6,7 @@ owners:
   - Will-Conklin
 applies_to:
   - plans
-last_updated: 2026-02-16
+last_updated: 2026-02-17
 related: []
 depends_on: []
 supersedes: []
@@ -92,10 +92,10 @@ proposed → accepted → in-progress → completed/archived
 - [Plan: Backend Session Security Hardening](./plan-backend-session-security-hardening.md)
 - [Plan: iOS Data and Performance Hardening](./plan-ios-data-performance-hardening.md)
 - [Plan: Backend Reliability and Durability Hardening](./plan-backend-reliability-durability.md)
+- [Plan: Tab Shell Accessibility Hardening](./plan-tab-shell-accessibility-hardening.md)
 
 ### Proposed
 
-- [Plan: Tab Shell Accessibility Hardening](./plan-tab-shell-accessibility-hardening.md)
 - [Plan: Visual Timeline (Pending Confirmation)](./plan-visual-timeline.md)
 - [Plan: Celebration Animations (Pending Confirmation)](./plan-celebration-animations.md)
 - [Plan: Advanced Accessibility Features (Pending Confirmation)](./plan-advanced-accessibility.md)

--- a/docs/plans/plan-tab-shell-accessibility-hardening.md
+++ b/docs/plans/plan-tab-shell-accessibility-hardening.md
@@ -1,14 +1,14 @@
 ---
 id: plan-tab-shell-accessibility-hardening
 type: plan
-status: proposed
+status: in-progress
 owners:
   - Will-Conklin
 applies_to:
   - ios
   - ux
   - accessibility
-last_updated: 2026-02-16
+last_updated: 2026-02-17
 related:
   - prd-0002-persistent-bottom-tab-bar
   - adr-0003-adhd-focused-ux-ui-guardrails
@@ -47,42 +47,42 @@ theme tokens and adding explicit VoiceOver and Dynamic Type validation.
 
 ### Phase 1: Tokenize Tab Shell Metrics
 
-**Status:** Not Started
+**Status:** Completed
 
-- [ ] Red:
-  - [ ] Add layout snapshot/assertion tests across key device classes and
+- [x] Red:
+  - [x] Add layout snapshot/assertion tests across key device classes and
         dynamic type sizes.
-  - [ ] Add tests locking tap-target minimum sizes for tab and CTA actions.
-- [ ] Green:
-  - [ ] Replace hardcoded tab shell constants (heights, divider sizes, spacers,
+  - [x] Add tests locking tap-target minimum sizes for tab and CTA actions.
+- [x] Green:
+  - [x] Replace hardcoded tab shell constants (heights, divider sizes, spacers,
         offsets) with `Theme.*` tokens.
-  - [ ] Keep current visual hierarchy and interaction affordances.
-- [ ] Refactor: group tab-shell-specific tokens under a dedicated theme namespace.
+  - [x] Keep current visual hierarchy and interaction affordances.
+- [x] Refactor: group tab-shell-specific tokens under a dedicated theme namespace.
 
 ### Phase 2: VoiceOver and Focus Order Hardening
 
-**Status:** Not Started
+**Status:** Completed
 
-- [ ] Red:
-  - [ ] Add UI/accessibility tests for VoiceOver labels/hints/values on tab and
+- [x] Red:
+  - [x] Add UI/accessibility tests for VoiceOver labels/hints/values on tab and
         CTA actions.
-  - [ ] Add traversal-order tests for expanded quick action tray.
-- [ ] Green:
-  - [ ] Ensure explicit labels/hints/traits for all tab and CTA controls.
-  - [ ] Ensure predictable focus order for expanded and collapsed CTA states.
-- [ ] Refactor: extract reusable accessibility modifiers for tab-shell controls.
+  - [x] Add traversal-order tests for expanded quick action tray.
+- [x] Green:
+  - [x] Ensure explicit labels/hints/traits for all tab and CTA controls.
+  - [x] Ensure predictable focus order for expanded and collapsed CTA states.
+- [x] Refactor: extract reusable accessibility modifiers for tab-shell controls.
 
 ### Phase 3: Dynamic Type and Reduced Motion Validation
 
-**Status:** Not Started
+**Status:** Completed
 
-- [ ] Red:
-  - [ ] Add validation tests for no clipping/overlap at larger content sizes.
-  - [ ] Add tests for reduced-motion animation/transition behavior.
-- [ ] Green:
-  - [ ] Adjust tab/CTA layout and transitions to maintain readability and
+- [x] Red:
+  - [x] Add validation tests for no clipping/overlap at larger content sizes.
+  - [x] Add tests for reduced-motion animation/transition behavior.
+- [x] Green:
+  - [x] Adjust tab/CTA layout and transitions to maintain readability and
         stability under accessibility settings.
-- [ ] Refactor: remove duplicated animation guards and keep a single motion
+- [x] Refactor: remove duplicated animation guards and keep a single motion
       policy path.
 
 ## Dependencies
@@ -112,3 +112,4 @@ theme tokens and adding explicit VoiceOver and Dynamic Type validation.
 | Date | Update |
 | --- | --- |
 | 2026-02-16 | Plan created from CODE_REVIEW_2026-02-15 UX/accessibility consistency findings. |
+| 2026-02-17 | Implemented tab-shell tokenization, accessibility metadata/focus order hardening, and dynamic-type/reduced-motion policy wiring with passing iOS tests. |

--- a/ios/Offload/App/TabShellPolicies.swift
+++ b/ios/Offload/App/TabShellPolicies.swift
@@ -1,0 +1,89 @@
+// Purpose: Shared policy values for tab shell layout, accessibility, and motion.
+// Authority: Code-level
+// Governed by: AGENTS.md
+// Additional instructions: Keep policy values deterministic and aligned with Theme tokens.
+
+import SwiftUI
+
+enum TabShellLayoutPolicy {
+    /// Returns the tab bar height tuned for the current Dynamic Type category.
+    static func barHeight(for dynamicTypeSize: DynamicTypeSize) -> CGFloat {
+        dynamicTypeSize.isAccessibilitySize ? Theme.TabShell.barHeightAccessibility : Theme.TabShell.barHeight
+    }
+
+    /// Returns quick-action spacing adjusted to avoid crowding at large text sizes.
+    static func quickActionTraySpacing(for dynamicTypeSize: DynamicTypeSize) -> CGFloat {
+        dynamicTypeSize.isAccessibilitySize
+            ? Theme.TabShell.quickActionTrayAccessibilitySpacing
+            : Theme.TabShell.quickActionTraySpacing
+    }
+
+    /// Returns the allowed line count for tab labels at the provided Dynamic Type size.
+    static func tabLabelLineLimit(for dynamicTypeSize: DynamicTypeSize) -> Int {
+        dynamicTypeSize.isAccessibilitySize ? 2 : 1
+    }
+
+    /// Returns label scaling bounds for tab text to minimize clipping at larger sizes.
+    static func tabLabelMinimumScaleFactor(for dynamicTypeSize: DynamicTypeSize) -> CGFloat {
+        dynamicTypeSize.isAccessibilitySize ? 0.9 : 1
+    }
+}
+
+enum TabShellMotionPolicy {
+    /// Returns an optional animation that disables non-essential motion when Reduce Motion is enabled.
+    static func animation(_ animation: Animation, reduceMotion: Bool) -> Animation? {
+        Theme.Animations.optionalMotion(animation, reduceMotion: reduceMotion)
+    }
+
+    /// Returns the initial bounce amount applied when opening the quick-action tray.
+    static func initialQuickActionBounce(reduceMotion: Bool) -> CGFloat {
+        reduceMotion ? 0 : Theme.TabShell.quickActionBounceInitial
+    }
+
+    /// Returns the overshoot bounce amount used for the quick-action tray spring.
+    static func overshootQuickActionBounce(reduceMotion: Bool) -> CGFloat {
+        reduceMotion ? 0 : Theme.TabShell.quickActionBounceOvershoot
+    }
+
+    /// Returns whether secondary bounce motion should run for the quick-action tray.
+    static func shouldAnimateBounce(reduceMotion: Bool) -> Bool {
+        !reduceMotion
+    }
+}
+
+enum TabShellAccessibility {
+    static let tabBarIdentifier = "tab-shell-root"
+    static let offloadGroupIdentifier = "tab-shell-offload-group"
+    static let offloadQuickTrayIdentifier = "tab-shell-offload-quick-tray"
+    static let mainButtonIdentifier = "tab-shell-offload-main"
+    static let quickWriteIdentifier = "tab-shell-offload-write"
+    static let quickVoiceIdentifier = "tab-shell-offload-voice"
+
+    static let offloadGroupLabel = "Offload"
+    static let offloadMainCollapsedLabel = "Offload"
+    static let offloadMainExpandedLabel = "Close Offload actions"
+    static let offloadMainHint = "Shows quick capture actions"
+    static let quickWriteLabel = "Write"
+    static let quickVoiceLabel = "Voice"
+    static let quickActionHintSuffix = "capture"
+    static let tabSelectionSelectedValue = "Selected"
+    static let tabSelectionNotSelectedValue = "Not selected"
+
+    static let quickWriteSortPriority: Double = 3
+    static let quickVoiceSortPriority: Double = 2
+    static let mainButtonSortPriority: Double = 1
+
+    /// Returns the accessibility identifier for a specific tab button.
+    static func identifier(for tab: MainTabView.Tab) -> String {
+        switch tab {
+        case .home:
+            "tab-shell-home"
+        case .review:
+            "tab-shell-review"
+        case .organize:
+            "tab-shell-organize"
+        case .account:
+            "tab-shell-account"
+        }
+    }
+}

--- a/ios/Offload/DesignSystem/Theme.swift
+++ b/ios/Offload/DesignSystem/Theme.swift
@@ -556,6 +556,51 @@ enum Theme {
         static let minimum = CGSize(width: 44, height: 44)
     }
 
+    // MARK: - Tab Shell
+
+    enum TabShell {
+        static let barHeight: CGFloat = 60
+        static let barHeightAccessibility: CGFloat = 76
+        static let barHorizontalPadding: CGFloat = Spacing.sm
+
+        static let dividerWidth: CGFloat = 1
+        static let dividerHeight: CGFloat = 24
+        static let dividerOpacityLight: Double = 0.3
+
+        static let barTopCornerRadius: CGFloat = CornerRadius.lg
+        static let barShadowOpacity: Double = 0.1
+        static let barShadowRadius: CGFloat = Shadows.elevationMd
+        static let barShadowOffsetY: CGFloat = -2
+
+        static let mainButtonSize: CGFloat = 64
+        static let mainButtonControlSize: CGFloat = HitTarget.minimum.width
+        static let mainButtonGlowDelta: CGFloat = 8
+        static let mainButtonIconSize: CGFloat = 24
+        static let mainButtonSlotPadding: CGFloat = 12
+        static var mainButtonSlotWidth: CGFloat { mainButtonSize + mainButtonSlotPadding }
+        static let mainButtonVerticalOffset: CGFloat = -Spacing.xl
+
+        static let quickActionLift: CGFloat = 64
+        static let quickActionButtonSize: CGFloat = 56
+        static let quickActionCornerRadius: CGFloat = 16
+        static let quickActionTrayHorizontalPadding: CGFloat = 12
+        static let quickActionTrayVerticalPadding: CGFloat = 8
+        static let quickActionTraySpacing: CGFloat = 20
+        static let quickActionTrayAccessibilitySpacing: CGFloat = 24
+        static let quickActionBounceInitial: CGFloat = 12
+        static let quickActionBounceOvershoot: CGFloat = -6
+        static let quickActionBounceSettleDelay: TimeInterval = 0.16
+
+        static let tabButtonControlSize: CGFloat = HitTarget.minimum.width
+        static let tabIconCircleSize: CGFloat = 44
+        static let tabIconFrameSize: CGFloat = 24
+        static let tabIconFontSize: CGFloat = 22
+        static let tabLabelFontSize: CGFloat = 10
+        static let tabLabelAccessibilityFontSize: CGFloat = 12
+        static let tabTopInset: CGFloat = Spacing.sm
+        static let tabBottomInset: CGFloat = 6
+    }
+
     // MARK: - Materials (kept but simplified)
 
     enum Materials {

--- a/ios/OffloadTests/TabShellPoliciesTests.swift
+++ b/ios/OffloadTests/TabShellPoliciesTests.swift
@@ -1,0 +1,50 @@
+// Purpose: Unit tests for tab shell accessibility and layout policies.
+// Authority: Code-level
+// Governed by: AGENTS.md
+// Additional instructions: Keep tests deterministic and avoid relying on network or time.
+
+@testable import Offload
+import SwiftUI
+import XCTest
+
+final class TabShellPoliciesTests: XCTestCase {
+    func testTabShellTapTargetsMeetMinimumSize() {
+        XCTAssertGreaterThanOrEqual(Theme.TabShell.tabButtonControlSize, Theme.HitTarget.minimum.width)
+        XCTAssertGreaterThanOrEqual(Theme.TabShell.quickActionButtonSize, Theme.HitTarget.minimum.width)
+        XCTAssertGreaterThanOrEqual(Theme.TabShell.mainButtonSize, Theme.HitTarget.minimum.width)
+    }
+
+    func testLayoutPolicyExpandsForAccessibilityDynamicType() {
+        XCTAssertGreaterThan(
+            TabShellLayoutPolicy.barHeight(for: .accessibility3),
+            TabShellLayoutPolicy.barHeight(for: .large)
+        )
+        XCTAssertGreaterThan(
+            TabShellLayoutPolicy.quickActionTraySpacing(for: .accessibility3),
+            TabShellLayoutPolicy.quickActionTraySpacing(for: .large)
+        )
+        XCTAssertEqual(TabShellLayoutPolicy.tabLabelLineLimit(for: .large), 1)
+        XCTAssertEqual(TabShellLayoutPolicy.tabLabelLineLimit(for: .accessibility3), 2)
+    }
+
+    func testMotionPolicyDisablesBounceWhenReduceMotionEnabled() {
+        XCTAssertEqual(TabShellMotionPolicy.initialQuickActionBounce(reduceMotion: true), 0)
+        XCTAssertEqual(TabShellMotionPolicy.overshootQuickActionBounce(reduceMotion: true), 0)
+        XCTAssertEqual(TabShellMotionPolicy.initialQuickActionBounce(reduceMotion: false), Theme.TabShell.quickActionBounceInitial)
+        XCTAssertEqual(TabShellMotionPolicy.overshootQuickActionBounce(reduceMotion: false), Theme.TabShell.quickActionBounceOvershoot)
+    }
+
+    func testAccessibilityMetadataUsesPredictableIdentifiersAndOrder() {
+        XCTAssertEqual(TabShellAccessibility.mainButtonIdentifier, "tab-shell-offload-main")
+        XCTAssertEqual(TabShellAccessibility.quickWriteIdentifier, "tab-shell-offload-write")
+        XCTAssertEqual(TabShellAccessibility.quickVoiceIdentifier, "tab-shell-offload-voice")
+        XCTAssertGreaterThan(
+            TabShellAccessibility.quickWriteSortPriority,
+            TabShellAccessibility.quickVoiceSortPriority
+        )
+        XCTAssertGreaterThan(
+            TabShellAccessibility.quickVoiceSortPriority,
+            TabShellAccessibility.mainButtonSortPriority
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- harden the custom tab shell and Offload CTA accessibility behavior
- introduce a dedicated `Theme.TabShell` token namespace and route tab/CTA metrics through it
- add shared tab-shell layout, motion, and accessibility policy helpers
- refactor `MainTabView` tab shell/CTA to use tokenized metrics, dynamic type policies, and reduced-motion-safe animations
- add explicit accessibility identifiers/labels/hints/traits/sort priorities for tab shell controls
- update plan docs to move Tab Shell Accessibility Hardening into in-progress with completed implementation phases

## Testing
- `just build`
- `just test`

Closes #192
