### PR TITLE
docs: add plan UAT status lifecycle

### DIFF
--- a/docs/plans/AGENTS.md
+++ b/docs/plans/AGENTS.md
@@ -7,7 +7,7 @@ owners:
 applies_to:
   - agents
   - plans
-last_updated: 2026-02-14
+last_updated: 2026-02-17
 related:
   - docs-agents
 depends_on: []
@@ -51,12 +51,13 @@ Define execution sequencing, milestones, and task breakdown (WHEN).
 ## Lifecycle
 
 - Created after design docs, before implementation
-- Status: proposed -> accepted -> in-progress -> completed/archived
+- Status: proposed -> accepted -> in-progress -> uat -> completed/archived
 - Updated as implementation progresses
 - Plans can only move to completed/archived when every item in the User Verification section is checked
 - Implementation PRs can be merged/closed when implementation tasks are complete, even if User Verification remains
 - If implementation is merged but User Verification is pending, create a follow-up GitHub issue labeled `uat`, add it to the Offload project, and link the plan and merged PR
-- Keep the plan in `in-progress` until User Verification is complete and the `uat` issue is closed
+- Move the plan to `uat` when implementation is merged and only User Verification remains
+- Keep the plan in `uat` until User Verification is complete and the `uat` issue is closed
 - Active plans tracked in `docs/plans/`
 - Completed plans moved to `docs/plans/_archived/`
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -34,14 +34,15 @@ introduce requirements, decisions, or architecture changes.
 ## Lifecycle
 
 ```text
-proposed → accepted → in-progress → completed/archived
+proposed → accepted → in-progress → uat → completed/archived
 ```
 
 | Status        | Meaning                                             |
 | ------------- | --------------------------------------------------- |
 | `proposed`    | Plan drafted, not yet approved                      |
 | `accepted`    | Approved and ready to start                         |
-| `in-progress` | Work underway or merged code awaiting verification  |
+| `in-progress` | Work underway                                       |
+| `uat`         | Implementation merged; pending User Verification    |
 | `completed`   | All work finished successfully                      |
 | `archived`    | Superseded, abandoned, or no longer relevant        |
 
@@ -50,7 +51,8 @@ proposed → accepted → in-progress → completed/archived
 - Merge and close implementation PRs when implementation work is complete.
 - If User Verification checklist items remain, open a follow-up GitHub issue labeled `uat`.
 - Add the `uat` issue to the Offload project and link it to the plan and merged PR.
-- Keep the plan status as `in-progress` until User Verification is complete.
+- Move the plan status to `uat` when implementation is merged and only User Verification remains.
+- Keep the plan status as `uat` until User Verification is complete.
 - Move the plan to `completed` (or `archived`) only after User Verification is fully checked and the `uat` issue is closed.
 
 ## What belongs here
@@ -72,27 +74,30 @@ proposed → accepted → in-progress → completed/archived
 
 - [Plan: Testing & Polish](./plan-testing-polish.md)
 - [Plan: Release Prep](./plan-release-prep.md)
+- [Plan: Diagnose Idle Memory Pressure](./plan-diagnose-idle-memory-pressure.md)
+- [Plan: Resolve Gesture Conflict on Collection Cards](./plan-resolve-gesture-conflict.md)
+- [Plan: Tag Relationship Refactor (Pending Confirmation)](./plan-tag-relationship-refactor.md)
+
+### UAT
+
+- [Plan: Backend API + Privacy Constraints MVP (Breakdown-First)](./plan-backend-api-privacy.md)
+- [Plan: Backend Session Security Hardening](./plan-backend-session-security-hardening.md)
+- [Plan: Backend Reliability and Durability Hardening](./plan-backend-reliability-durability.md)
 - [Plan: Convert Plans and Lists](./plan-convert-plans-lists.md)
 - [Plan: Drag and Drop Ordering](./plan-drag-drop-ordering.md)
 - [Plan: Item Search by Text or Tag](./plan-item-search-tags.md)
+- [Plan: iOS Data and Performance Hardening](./plan-ios-data-performance-hardening.md)
 - [Plan: UX & Accessibility Audit Fixes](./plan-ux-accessibility-audit-fixes.md)
+- [Plan: Tab Shell Accessibility Hardening](./plan-tab-shell-accessibility-hardening.md)
 - [Plan: View Decomposition](./plan-view-decomposition.md)
 - [Plan: Fix Swipe-to-Delete in Organize View](./plan-fix-swipe-to-delete.md)
-- [Plan: Resolve Gesture Conflict on Collection Cards](./plan-resolve-gesture-conflict.md)
 - [Plan: Atomic Move to Collection](./plan-fix-atomic-move-to-collection.md)
 - [Plan: Fix Orphaned Collection Links in CollectionItemRepository](./plan-fix-orphaned-collection-links.md)
 - [Plan: Fix Voice Recording Service Off-Main-Actor Mutations](./plan-fix-voice-recording-threading.md)
 - [Plan: Fix Collection Form Sheet Dismissing on Save Failure](./plan-fix-collection-form-dismissal.md)
-- [Plan: Tag Relationship Refactor (Pending Confirmation)](./plan-tag-relationship-refactor.md)
 - [Plan: Fix Structured Item Position Collisions](./plan-fix-structured-item-position-collisions.md)
 - [Plan: Fix Tag Usage Semantics](./plan-fix-tag-usage-semantics.md)
-- [Plan: Diagnose Idle Memory Pressure](./plan-diagnose-idle-memory-pressure.md)
 - [Plan: Fix Collection Position Backfill](./plan-fix-collection-position-backfill.md)
-- [Plan: Backend API + Privacy Constraints MVP (Breakdown-First)](./plan-backend-api-privacy.md)
-- [Plan: Backend Session Security Hardening](./plan-backend-session-security-hardening.md)
-- [Plan: iOS Data and Performance Hardening](./plan-ios-data-performance-hardening.md)
-- [Plan: Backend Reliability and Durability Hardening](./plan-backend-reliability-durability.md)
-- [Plan: Tab Shell Accessibility Hardening](./plan-tab-shell-accessibility-hardening.md)
 
 ### Proposed
 

--- a/docs/plans/plan-backend-api-privacy.md
+++ b/docs/plans/plan-backend-api-privacy.md
@@ -1,14 +1,14 @@
 ---
 id: plan-backend-api-privacy
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
   - backend
   - ai
   - privacy
-last_updated: 2026-02-15
+last_updated: 2026-02-17
 related:
   - plan-roadmap
   - adr-0008-backend-api-privacy-mvp

--- a/docs/plans/plan-backend-reliability-durability.md
+++ b/docs/plans/plan-backend-reliability-durability.md
@@ -1,14 +1,14 @@
 ---
 id: plan-backend-reliability-durability
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
   - backend
   - ai
   - reliability
-last_updated: 2026-02-16
+last_updated: 2026-02-17
 related:
   - plan-backend-api-privacy
   - adr-0008-backend-api-privacy-mvp

--- a/docs/plans/plan-backend-session-security-hardening.md
+++ b/docs/plans/plan-backend-session-security-hardening.md
@@ -1,14 +1,14 @@
 ---
 id: plan-backend-session-security-hardening
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
   - backend
   - ai
   - security
-last_updated: 2026-02-16
+last_updated: 2026-02-17
 related:
   - plan-backend-api-privacy
   - adr-0008-backend-api-privacy-mvp

--- a/docs/plans/plan-convert-plans-lists.md
+++ b/docs/plans/plan-convert-plans-lists.md
@@ -1,12 +1,12 @@
 ---
 id: plan-convert-plans-lists
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
   - organize
-last_updated: 2026-02-08
+last_updated: 2026-02-17
 related:
   - prd-0003-convert-plans-lists
   - adr-0005-collection-ordering-and-hierarchy-persistence

--- a/docs/plans/plan-drag-drop-ordering.md
+++ b/docs/plans/plan-drag-drop-ordering.md
@@ -1,12 +1,12 @@
 ---
 id: plan-drag-drop-ordering
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
   - organize
-last_updated: 2026-02-04
+last_updated: 2026-02-17
 related:
   - prd-0004-drag-drop-ordering
   - adr-0005-collection-ordering-and-hierarchy-persistence

--- a/docs/plans/plan-fix-atomic-move-to-collection.md
+++ b/docs/plans/plan-fix-atomic-move-to-collection.md
@@ -1,14 +1,14 @@
 ---
 id: plan-fix-atomic-move-to-collection
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
   - capture
   - organize
   - data-model
-last_updated: 2026-02-14
+last_updated: 2026-02-17
 related: []
 depends_on: []
 supersedes: []

--- a/docs/plans/plan-fix-collection-form-dismissal.md
+++ b/docs/plans/plan-fix-collection-form-dismissal.md
@@ -1,7 +1,7 @@
 ---
 id: plan-fix-collection-form-dismissal
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
@@ -9,7 +9,7 @@ applies_to:
   - organize
   - bug-fix
   - forms
-last_updated: 2026-02-13
+last_updated: 2026-02-17
 related: []
 depends_on: []
 supersedes: []

--- a/docs/plans/plan-fix-collection-position-backfill.md
+++ b/docs/plans/plan-fix-collection-position-backfill.md
@@ -1,14 +1,14 @@
 ---
 id: plan-fix-collection-position-backfill
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
   - organize
   - ordering
   - migration
-last_updated: 2026-02-15
+last_updated: 2026-02-17
 related: []
 depends_on: []
 supersedes: []

--- a/docs/plans/plan-fix-orphaned-collection-links.md
+++ b/docs/plans/plan-fix-orphaned-collection-links.md
@@ -1,14 +1,14 @@
 ---
 id: plan-fix-orphaned-collection-links
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
   - data-integrity
   - repositories
   - bug-fix
-last_updated: 2026-02-13
+last_updated: 2026-02-17
 related: []
 depends_on: []
 supersedes: []

--- a/docs/plans/plan-fix-structured-item-position-collisions.md
+++ b/docs/plans/plan-fix-structured-item-position-collisions.md
@@ -1,14 +1,14 @@
 ---
 id: plan-fix-structured-item-position-collisions
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
   - organize
   - capture
   - ordering
-last_updated: 2026-02-15
+last_updated: 2026-02-17
 related:
   - plan-drag-drop-ordering
 depends_on: []

--- a/docs/plans/plan-fix-swipe-to-delete.md
+++ b/docs/plans/plan-fix-swipe-to-delete.md
@@ -1,12 +1,12 @@
 ---
 id: plan-fix-swipe-to-delete
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
   - organize
-last_updated: 2026-02-13
+last_updated: 2026-02-17
 related:
   - plan-resolve-gesture-conflict
   - plan-drag-drop-ordering

--- a/docs/plans/plan-fix-tag-usage-semantics.md
+++ b/docs/plans/plan-fix-tag-usage-semantics.md
@@ -1,14 +1,14 @@
 ---
 id: plan-fix-tag-usage-semantics
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
   - tags
   - capture
   - organize
-last_updated: 2026-02-15
+last_updated: 2026-02-17
 related:
   - plan-fix-tag-assignment
   - plan-tag-relationship-refactor

--- a/docs/plans/plan-fix-voice-recording-threading.md
+++ b/docs/plans/plan-fix-voice-recording-threading.md
@@ -1,7 +1,7 @@
 ---
 id: plan-fix-voice-recording-threading
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
@@ -9,7 +9,7 @@ applies_to:
   - voice
   - capture
   - bug-fix
-last_updated: 2026-02-14
+last_updated: 2026-02-17
 related:
   - design-voice-capture-testing-guide
   - design-voice-capture-test-results

--- a/docs/plans/plan-ios-data-performance-hardening.md
+++ b/docs/plans/plan-ios-data-performance-hardening.md
@@ -1,7 +1,7 @@
 ---
 id: plan-ios-data-performance-hardening
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
@@ -43,7 +43,7 @@ lazy migration, and typed metadata access with backward compatibility.
 ## Phases
 
 Phase completion below reflects implementation status. Plan status remains
-`in-progress` until User Verification is complete.
+`uat` until User Verification is complete.
 
 ### Phase 1: Reorder Complexity Refactor
 

--- a/docs/plans/plan-item-search-tags.md
+++ b/docs/plans/plan-item-search-tags.md
@@ -1,13 +1,13 @@
 ---
 id: plan-item-search-tags
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
   - capture
   - organize
-last_updated: 2026-02-03
+last_updated: 2026-02-17
 related:
   - prd-0005-item-search-tags
   - adr-0003-adhd-focused-ux-ui-guardrails

--- a/docs/plans/plan-tab-shell-accessibility-hardening.md
+++ b/docs/plans/plan-tab-shell-accessibility-hardening.md
@@ -1,7 +1,7 @@
 ---
 id: plan-tab-shell-accessibility-hardening
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:

--- a/docs/plans/plan-ux-accessibility-audit-fixes.md
+++ b/docs/plans/plan-ux-accessibility-audit-fixes.md
@@ -1,12 +1,12 @@
 ---
 id: plan-ux-accessibility-audit-fixes
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
   - ios
-last_updated: 2026-02-09
+last_updated: 2026-02-17
 related:
   - plan-advanced-accessibility
   - adr-0003-adhd-focused-ux-ui-guardrails

--- a/docs/plans/plan-view-decomposition.md
+++ b/docs/plans/plan-view-decomposition.md
@@ -1,12 +1,12 @@
 ---
 id: plan-view-decomposition
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
   - ios
-last_updated: 2026-02-09
+last_updated: 2026-02-17
 related:
   - plan-roadmap
 depends_on: []

--- a/docs/reference/reference-frontmatter-schema.md
+++ b/docs/reference/reference-frontmatter-schema.md
@@ -8,7 +8,7 @@ applies_to:
   - reference
   - documentation
   - agents
-last_updated: 2026-01-25
+last_updated: 2026-02-17
 related:
   - docs-agents
 depends_on: []
@@ -98,6 +98,7 @@ decision-makers: array[string]# Names of decision makers
   - `accepted` — Formally accepted, authoritative
   - `active` — Currently in use (reference docs)
   - `in-progress` — Implementation underway (plans)
+  - `uat` — Implementation complete; pending user verification (plans)
   - `completed` — Finished (plans, research)
   - `archived` — No longer active, preserved for history
   - `deprecated` — Superseded, should not be used
@@ -106,7 +107,7 @@ decision-makers: array[string]# Names of decision makers
   - ADRs: proposed → accepted → (superseded/deprecated)
   - PRDs: proposed → draft → accepted → archived
   - Design: proposed → accepted → archived
-  - Plans: proposed → accepted → in-progress → completed/archived
+  - Plans: proposed → accepted → in-progress → uat → completed/archived
   - Research: active → completed
   - Reference: draft → active → deprecated
 


### PR DESCRIPTION
## Summary
- add a dedicated `uat` lifecycle status for plans in docs lifecycle guidance
- update plan documentation rules to move merged implementation work from `in-progress` to `uat`
- recategorize verification-only plan docs to `status: uat` and refresh `last_updated`

## Testing
- `just lint`
