### PR TITLE
docs: align plan acceptance and uat workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,9 @@ just ci-local                 # Run lint + backend checks + iOS tests
   all plan items are complete except User Verification; move to Done after the
   PR merges
 - If an implementation PR merges while plan User Verification tasks remain:
-  open a new GitHub issue labeled `uat`, add it to the Offload project, and
-  link the plan + merged PR; keep the plan `in-progress` until verification is
-  complete
+  open a new GitHub issue labeled `uat`, add it to the Offload project with
+  status `Ready`, and link the plan + merged PR; keep the plan `uat` until
+  verification is complete
 - For all new GitHub issues (not only plan issues): always add them to the
   Offload project during creation or immediately after creation
 - For all new GitHub issues: apply labels at creation time and never leave an
@@ -88,6 +88,8 @@ just ci-local                 # Run lint + backend checks + iOS tests
 - Use `bug` for defects/regressions, `enhancement` for feature or implementation
   work, and `documentation` for docs-only work
 - Use `uat` only for post-merge user verification follow-up issues
+- Any issue labeled `uat` must be placed in project status `Ready` (not
+  `Backlog`)
 - Use `ux` as an additional label (with the primary label above) when the issue
   is primarily about UX/UI behavior
 - If label selection is ambiguous, ask the user before creating or relabeling

--- a/docs/plans/AGENTS.md
+++ b/docs/plans/AGENTS.md
@@ -7,7 +7,7 @@ owners:
 applies_to:
   - agents
   - plans
-last_updated: 2026-02-17
+last_updated: 2026-02-18
 related:
   - docs-agents
 depends_on: []
@@ -53,9 +53,17 @@ Define execution sequencing, milestones, and task breakdown (WHEN).
 - Created after design docs, before implementation
 - Status: proposed -> accepted -> in-progress -> uat -> completed/archived
 - Updated as implementation progresses
+- If a user explicitly instructs implementation to begin, treat that instruction
+  as plan acceptance unless the plan is marked pending confirmation.
+- On implicit acceptance, set `accepted_by` to the GitHub handle format
+  (`@username`) for the active GitHub account and set `accepted_at` to the date
+  implementation first began.
+- Prefer the authenticated `gh` account login as the source for
+  `accepted_by` and use `git config user.name` only as a fallback if GitHub
+  identity is unavailable.
 - Plans can only move to completed/archived when every item in the User Verification section is checked
 - Implementation PRs can be merged/closed when implementation tasks are complete, even if User Verification remains
-- If implementation is merged but User Verification is pending, create a follow-up GitHub issue labeled `uat`, add it to the Offload project, and link the plan and merged PR
+- If implementation is merged but User Verification is pending, create a follow-up GitHub issue labeled `uat`, add it to the Offload project with status `Ready`, and link the plan and merged PR
 - Move the plan to `uat` when implementation is merged and only User Verification remains
 - Keep the plan in `uat` until User Verification is complete and the `uat` issue is closed
 - Active plans tracked in `docs/plans/`
@@ -75,12 +83,14 @@ Define execution sequencing, milestones, and task breakdown (WHEN).
   - Use `enhancement` for feature/implementation plan issues
   - Use `bug` when the plan is specifically to fix a defect/regression
   - Use `documentation` for docs-only plan issues
+  - Any issue labeled `uat` must be placed in project status `Ready` (not
+    `Backlog`)
   - Use `ux` as an additional label when the plan primarily targets UX/UI
     behavior
   - **Always add a comment to related issues when a plan is created**, linking to the plan document and summarizing the approach
   - Include plan status, key phases, and next steps in the issue comment
   - When work is merged but User Verification remains, create and link a
-    `uat`-labeled issue for verification follow-up
+    `uat`-labeled issue for verification follow-up and place it in project status `Ready`
   - After plan issue/PR updates, run an issue/project sync audit and fix any
     mismatches before finishing (project membership, required labels, and lane
     alignment such as `In review` only with an open PR)

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -6,7 +6,7 @@ owners:
   - Will-Conklin
 applies_to:
   - plans
-last_updated: 2026-02-17
+last_updated: 2026-02-18
 related: []
 depends_on: []
 supersedes: []
@@ -50,10 +50,20 @@ proposed → accepted → in-progress → uat → completed/archived
 
 - Merge and close implementation PRs when implementation work is complete.
 - If User Verification checklist items remain, open a follow-up GitHub issue labeled `uat`.
-- Add the `uat` issue to the Offload project and link it to the plan and merged PR.
+- Add the `uat` issue to the Offload project with status `Ready` and link it to the plan and merged PR.
 - Move the plan status to `uat` when implementation is merged and only User Verification remains.
 - Keep the plan status as `uat` until User Verification is complete.
 - Move the plan to `completed` (or `archived`) only after User Verification is fully checked and the `uat` issue is closed.
+
+### Acceptance Rule
+
+- Explicit user instruction to begin implementation counts as plan acceptance
+  unless the plan is marked pending confirmation.
+- When this occurs, set `accepted_by` to GitHub handle format (`@username`)
+  for the active GitHub account and set `accepted_at` to the date
+  implementation first began.
+- Prefer the authenticated `gh` account login as the source for
+  `accepted_by`; use `git config user.name` only as a fallback.
 
 ## What belongs here
 
@@ -72,14 +82,16 @@ proposed → accepted → in-progress → uat → completed/archived
 
 ### In Progress
 
+- None currently.
+
+### Accepted
+
 - [Plan: Testing & Polish](./plan-testing-polish.md)
 - [Plan: Release Prep](./plan-release-prep.md)
-- [Plan: Diagnose Idle Memory Pressure](./plan-diagnose-idle-memory-pressure.md)
-- [Plan: Resolve Gesture Conflict on Collection Cards](./plan-resolve-gesture-conflict.md)
-- [Plan: Tag Relationship Refactor (Pending Confirmation)](./plan-tag-relationship-refactor.md)
 
 ### UAT
 
+- [Plan: Diagnose Idle Memory Pressure](./plan-diagnose-idle-memory-pressure.md)
 - [Plan: Backend API + Privacy Constraints MVP (Breakdown-First)](./plan-backend-api-privacy.md)
 - [Plan: Backend Session Security Hardening](./plan-backend-session-security-hardening.md)
 - [Plan: Backend Reliability and Durability Hardening](./plan-backend-reliability-durability.md)
@@ -90,6 +102,7 @@ proposed → accepted → in-progress → uat → completed/archived
 - [Plan: UX & Accessibility Audit Fixes](./plan-ux-accessibility-audit-fixes.md)
 - [Plan: Tab Shell Accessibility Hardening](./plan-tab-shell-accessibility-hardening.md)
 - [Plan: View Decomposition](./plan-view-decomposition.md)
+- [Plan: Resolve Gesture Conflict on Collection Cards](./plan-resolve-gesture-conflict.md)
 - [Plan: Fix Swipe-to-Delete in Organize View](./plan-fix-swipe-to-delete.md)
 - [Plan: Atomic Move to Collection](./plan-fix-atomic-move-to-collection.md)
 - [Plan: Fix Orphaned Collection Links in CollectionItemRepository](./plan-fix-orphaned-collection-links.md)
@@ -106,6 +119,8 @@ proposed → accepted → in-progress → uat → completed/archived
 - [Plan: Advanced Accessibility Features (Pending Confirmation)](./plan-advanced-accessibility.md)
 - [Plan: AI Organization Flows & Review Screen (Pending Confirmation)](./plan-ai-organization-flows.md)
 - [Plan: AI Pricing & Limits (Pending Confirmation)](./plan-ai-pricing-limits.md)
+- [Plan: Codebase Audit Cleanup](./plan-codebase-audit-cleanup.md)
+- [Plan: Tag Relationship Refactor (Pending Confirmation)](./plan-tag-relationship-refactor.md)
 - [Plan: Trailing-Gutter Swipe Delete Affordance](./plan-trailing-gutter-swipe-delete-affordance.md)
 
 ### Completed

--- a/docs/plans/plan-backend-api-privacy.md
+++ b/docs/plans/plan-backend-api-privacy.md
@@ -21,10 +21,11 @@ depends_on:
   - docs/adrs/adr-0008-backend-api-privacy-mvp.md
   - docs/design/design-backend-api-privacy-mvp.md
 supersedes: []
-accepted_by: Will-Conklin
+accepted_by: @Will-Conklin
 accepted_at: 2026-02-15
 related_issues:
   - https://github.com/Will-Conklin/Offload/issues/111
+  - https://github.com/Will-Conklin/Offload/issues/207
 structure_notes:
   - "Section order: Overview; Goals; Phases; Dependencies; Risks; User Verification; Progress."
   - "Implementation scope is breakdown-first backend MVP with explicit cloud opt-in and zero content retention."

--- a/docs/plans/plan-backend-reliability-durability.md
+++ b/docs/plans/plan-backend-reliability-durability.md
@@ -8,7 +8,7 @@ applies_to:
   - backend
   - ai
   - reliability
-last_updated: 2026-02-17
+last_updated: 2026-02-18
 related:
   - plan-backend-api-privacy
   - adr-0008-backend-api-privacy-mvp
@@ -17,9 +17,10 @@ depends_on:
   - docs/adrs/adr-0008-backend-api-privacy-mvp.md
   - docs/design/design-backend-api-privacy-mvp.md
 supersedes: []
-accepted_by: null
-accepted_at: null
-related_issues: []
+accepted_by: @Will-Conklin
+accepted_at: 2026-02-16
+related_issues:
+  - https://github.com/Will-Conklin/Offload/issues/208
 structure_notes:
   - "Section order: Overview; Goals; Phases; Dependencies; Risks; User Verification; Progress."
 ---

--- a/docs/plans/plan-backend-session-security-hardening.md
+++ b/docs/plans/plan-backend-session-security-hardening.md
@@ -8,7 +8,7 @@ applies_to:
   - backend
   - ai
   - security
-last_updated: 2026-02-17
+last_updated: 2026-02-18
 related:
   - plan-backend-api-privacy
   - adr-0008-backend-api-privacy-mvp
@@ -17,9 +17,10 @@ depends_on:
   - docs/adrs/adr-0008-backend-api-privacy-mvp.md
   - docs/design/design-backend-api-privacy-mvp.md
 supersedes: []
-accepted_by: null
-accepted_at: null
-related_issues: []
+accepted_by: @Will-Conklin
+accepted_at: 2026-02-16
+related_issues:
+  - https://github.com/Will-Conklin/Offload/issues/209
 structure_notes:
   - "Section order: Overview; Goals; Phases; Dependencies; Risks; User Verification; Progress."
 ---

--- a/docs/plans/plan-convert-plans-lists.md
+++ b/docs/plans/plan-convert-plans-lists.md
@@ -6,17 +6,18 @@ owners:
   - Will-Conklin
 applies_to:
   - organize
-last_updated: 2026-02-17
+last_updated: 2026-02-18
 related:
   - prd-0003-convert-plans-lists
   - adr-0005-collection-ordering-and-hierarchy-persistence
   - design-convert-plans-lists
 depends_on: []
 supersedes: []
-accepted_by: null
-accepted_at: null
+accepted_by: @Will-Conklin
+accepted_at: 2026-01-22
 related_issues:
   - https://github.com/Will-Conklin/offload/issues/104
+  - https://github.com/Will-Conklin/Offload/issues/210
 structure_notes:
   - "Section order: Overview; Goals; Phases; Dependencies; Risks; User Verification; Progress."
 ---

--- a/docs/plans/plan-diagnose-idle-memory-pressure.md
+++ b/docs/plans/plan-diagnose-idle-memory-pressure.md
@@ -1,19 +1,19 @@
 ---
 id: plan-diagnose-idle-memory-pressure
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
   - diagnostics
   - memory
   - startup
-last_updated: 2026-02-15
+last_updated: 2026-02-18
 related: []
 depends_on: []
 supersedes: []
-accepted_by: null
-accepted_at: null
+accepted_by: @Will-Conklin
+accepted_at: 2026-02-15
 related_issues:
   - https://github.com/Will-Conklin/Offload/issues/175
 implementation_pr: https://github.com/Will-Conklin/Offload/pull/176
@@ -85,7 +85,7 @@ lifecycle memory telemetry so mitigation work can be evidence-driven.
 
 ### Phase 5: Validation and Evidence Collection
 
-**Status:** In Progress
+**Status:** UAT
 
 - [x] Run `just build`.
 - [x] Run `just test`.
@@ -126,3 +126,4 @@ lifecycle memory telemetry so mitigation work can be evidence-driven.
 | 2026-02-14 | Phases 1-4 implemented; Phase 5 validation in progress. |
 | 2026-02-14 | `just build`, `just test`, and `just lint` passed. |
 | 2026-02-15 | Diagnostics instrumentation merged in PR #176; issue #175 remains open for ongoing investigation/validation. |
+| 2026-02-18 | Plan moved to `uat`; remaining work is user verification and validation follow-up via issue #175. |

--- a/docs/plans/plan-drag-drop-ordering.md
+++ b/docs/plans/plan-drag-drop-ordering.md
@@ -6,7 +6,7 @@ owners:
   - Will-Conklin
 applies_to:
   - organize
-last_updated: 2026-02-17
+last_updated: 2026-02-18
 related:
   - prd-0004-drag-drop-ordering
   - adr-0005-collection-ordering-and-hierarchy-persistence
@@ -14,10 +14,11 @@ related:
   - design-drag-drop-ordering
 depends_on: []
 supersedes: []
-accepted_by: null
-accepted_at: null
+accepted_by: @Will-Conklin
+accepted_at: 2026-01-22
 related_issues:
   - https://github.com/Will-Conklin/offload/issues/105
+  - https://github.com/Will-Conklin/Offload/issues/211
   - https://github.com/Will-Conklin/offload/pull/130
 structure_notes:
   - "Section order: Overview; Goals; Phases; Dependencies; Risks; User Verification; Progress."

--- a/docs/plans/plan-fix-atomic-move-to-collection.md
+++ b/docs/plans/plan-fix-atomic-move-to-collection.md
@@ -8,14 +8,15 @@ applies_to:
   - capture
   - organize
   - data-model
-last_updated: 2026-02-17
+last_updated: 2026-02-18
 related: []
 depends_on: []
 supersedes: []
-accepted_by: null
-accepted_at: null
+accepted_by: @Will-Conklin
+accepted_at: 2026-02-13
 related_issues:
   - https://github.com/Will-Conklin/Offload/issues/161
+  - https://github.com/Will-Conklin/Offload/issues/212
 structure_notes:
   - "Section order: Overview; Context; Goals; Phases; Dependencies; Risks; User Verification; Progress."
 ---

--- a/docs/plans/plan-fix-collection-form-dismissal.md
+++ b/docs/plans/plan-fix-collection-form-dismissal.md
@@ -13,7 +13,7 @@ last_updated: 2026-02-17
 related: []
 depends_on: []
 supersedes: []
-accepted_by: Will-Conklin
+accepted_by: @Will-Conklin
 accepted_at: 2026-02-13
 related_issues:
   - https://github.com/Will-Conklin/offload/issues/146

--- a/docs/plans/plan-fix-collection-position-backfill.md
+++ b/docs/plans/plan-fix-collection-position-backfill.md
@@ -8,12 +8,12 @@ applies_to:
   - organize
   - ordering
   - migration
-last_updated: 2026-02-17
+last_updated: 2026-02-18
 related: []
 depends_on: []
 supersedes: []
-accepted_by: null
-accepted_at: null
+accepted_by: @Will-Conklin
+accepted_at: 2026-02-15
 related_issues:
   - https://github.com/Will-Conklin/Offload/issues/163
   - https://github.com/Will-Conklin/Offload/issues/182

--- a/docs/plans/plan-fix-orphaned-collection-links.md
+++ b/docs/plans/plan-fix-orphaned-collection-links.md
@@ -12,7 +12,7 @@ last_updated: 2026-02-17
 related: []
 depends_on: []
 supersedes: []
-accepted_by: Will-Conklin
+accepted_by: @Will-Conklin
 accepted_at: 2026-02-12
 related_issues:
   - https://github.com/Will-Conklin/offload/issues/147

--- a/docs/plans/plan-fix-structured-item-position-collisions.md
+++ b/docs/plans/plan-fix-structured-item-position-collisions.md
@@ -8,13 +8,13 @@ applies_to:
   - organize
   - capture
   - ordering
-last_updated: 2026-02-17
+last_updated: 2026-02-18
 related:
   - plan-drag-drop-ordering
 depends_on: []
 supersedes: []
-accepted_by: null
-accepted_at: null
+accepted_by: @Will-Conklin
+accepted_at: 2026-02-15
 related_issues:
   - https://github.com/Will-Conklin/Offload/issues/162
   - https://github.com/Will-Conklin/Offload/issues/180

--- a/docs/plans/plan-fix-swipe-to-delete.md
+++ b/docs/plans/plan-fix-swipe-to-delete.md
@@ -13,7 +13,7 @@ related:
 depends_on:
   - plan-drag-drop-ordering
 supersedes: []
-accepted_by: Will-Conklin
+accepted_by: @Will-Conklin
 accepted_at: 2026-02-13
 related_issues:
   - https://github.com/Will-Conklin/offload/issues/140

--- a/docs/plans/plan-fix-tag-assignment.md
+++ b/docs/plans/plan-fix-tag-assignment.md
@@ -8,13 +8,13 @@ applies_to:
   - capture
   - organize
   - tags
-last_updated: 2026-02-11
+last_updated: 2026-02-18
 related:
   - plan-tag-relationship-refactor
 depends_on: []
 supersedes: []
-accepted_by: null
-accepted_at: null
+accepted_by: @Will-Conklin
+accepted_at: 2026-02-11
 related_issues:
   - https://github.com/Will-Conklin/offload/issues/141
   - https://github.com/Will-Conklin/offload/pull/144

--- a/docs/plans/plan-fix-tag-usage-semantics.md
+++ b/docs/plans/plan-fix-tag-usage-semantics.md
@@ -8,14 +8,14 @@ applies_to:
   - tags
   - capture
   - organize
-last_updated: 2026-02-17
+last_updated: 2026-02-18
 related:
   - plan-fix-tag-assignment
   - plan-tag-relationship-refactor
 depends_on: []
 supersedes: []
-accepted_by: null
-accepted_at: null
+accepted_by: @Will-Conklin
+accepted_at: 2026-02-15
 related_issues:
   - https://github.com/Will-Conklin/Offload/issues/164
   - https://github.com/Will-Conklin/Offload/issues/181

--- a/docs/plans/plan-fix-voice-recording-threading.md
+++ b/docs/plans/plan-fix-voice-recording-threading.md
@@ -15,7 +15,7 @@ related:
   - design-voice-capture-test-results
 depends_on: []
 supersedes: []
-accepted_by: Will-Conklin
+accepted_by: @Will-Conklin
 accepted_at: 2026-02-13
 related_issues:
   - https://github.com/Will-Conklin/offload/issues/145

--- a/docs/plans/plan-ios-data-performance-hardening.md
+++ b/docs/plans/plan-ios-data-performance-hardening.md
@@ -8,7 +8,7 @@ applies_to:
   - ios
   - performance
   - persistence
-last_updated: 2026-02-17
+last_updated: 2026-02-18
 related:
   - prd-0001-product-requirements
   - prd-0007-smart-task-breakdown
@@ -17,9 +17,10 @@ depends_on:
   - docs/prds/prd-0001-product-requirements.md
   - docs/adrs/adr-0005-collection-ordering-and-hierarchy-persistence.md
 supersedes: []
-accepted_by: null
-accepted_at: null
-related_issues: []
+accepted_by: @Will-Conklin
+accepted_at: 2026-02-16
+related_issues:
+  - https://github.com/Will-Conklin/Offload/issues/213
 structure_notes:
   - "Section order: Overview; Goals; Phases; Dependencies; Risks; User Verification; Progress."
 ---

--- a/docs/plans/plan-item-search-tags.md
+++ b/docs/plans/plan-item-search-tags.md
@@ -7,7 +7,7 @@ owners:
 applies_to:
   - capture
   - organize
-last_updated: 2026-02-17
+last_updated: 2026-02-18
 related:
   - prd-0005-item-search-tags
   - adr-0003-adhd-focused-ux-ui-guardrails
@@ -15,10 +15,11 @@ related:
   - design-item-search-tags
 depends_on: []
 supersedes: []
-accepted_by: null
-accepted_at: null
+accepted_by: @Will-Conklin
+accepted_at: 2026-01-22
 related_issues:
   - https://github.com/Will-Conklin/offload/issues/106
+  - https://github.com/Will-Conklin/Offload/issues/214
 structure_notes:
   - "Section order: Overview; Goals; Phases; Dependencies; Risks; User Verification; Progress."
 ---

--- a/docs/plans/plan-release-prep.md
+++ b/docs/plans/plan-release-prep.md
@@ -1,12 +1,12 @@
 ---
 id: plan-release-prep
 type: plan
-status: in-progress
+status: accepted
 owners:
   - Will-Conklin
 applies_to:
   - launch-release
-last_updated: 2026-02-16
+last_updated: 2026-02-18
 related:
   - plan-roadmap
   - plan-testing-polish
@@ -15,8 +15,8 @@ related:
 depends_on:
   - plan-testing-polish
 supersedes: []
-accepted_by: null
-accepted_at: null
+accepted_by: @Will-Conklin
+accepted_at: 2026-01-25
 related_issues:
   - https://github.com/Will-Conklin/offload/issues/113
 structure_notes:
@@ -110,3 +110,4 @@ metadata, and TestFlight distribution.
 | 2026-01-20 | Plan created from roadmap split. |
 | 2026-02-09 | Plan refined with concrete tasks and cross-references. |
 | 2026-02-16 | Added security release gate checklist aligned with backend hardening review recommendations. |
+| 2026-02-18 | Returned to `accepted`; implementation has not started yet. |

--- a/docs/plans/plan-resolve-gesture-conflict.md
+++ b/docs/plans/plan-resolve-gesture-conflict.md
@@ -1,7 +1,7 @@
 ---
 id: plan-resolve-gesture-conflict
 type: plan
-status: in-progress
+status: uat
 owners:
   - Will-Conklin
 applies_to:
@@ -9,7 +9,7 @@ applies_to:
   - organize
   - ux
   - accessibility
-last_updated: 2026-02-12
+last_updated: 2026-02-17
 related:
   - plan-drag-drop-ordering
   - prd-0004-drag-drop-ordering
@@ -17,10 +17,11 @@ related:
   - reference-drag-drop-ordering
 depends_on: []
 supersedes: []
-accepted_by: Will-Conklin
+accepted_by: @Will-Conklin
 accepted_at: 2026-02-12
 related_issues:
   - https://github.com/Will-Conklin/offload/issues/142
+  - https://github.com/Will-Conklin/Offload/issues/218
 structure_notes:
   - "Section order: Overview; Goals; Phases; Dependencies; Risks; User Verification; Progress."
 ---

--- a/docs/plans/plan-tab-shell-accessibility-hardening.md
+++ b/docs/plans/plan-tab-shell-accessibility-hardening.md
@@ -8,7 +8,7 @@ applies_to:
   - ios
   - ux
   - accessibility
-last_updated: 2026-02-17
+last_updated: 2026-02-18
 related:
   - prd-0002-persistent-bottom-tab-bar
   - adr-0003-adhd-focused-ux-ui-guardrails
@@ -21,9 +21,10 @@ depends_on:
   - docs/adrs/adr-0004-tab-bar-navigation-shell-and-offload-cta.md
   - docs/design/design-persistent-bottom-tab-bar.md
 supersedes: []
-accepted_by: null
-accepted_at: null
-related_issues: []
+accepted_by: @Will-Conklin
+accepted_at: 2026-02-17
+related_issues:
+  - https://github.com/Will-Conklin/Offload/issues/215
 structure_notes:
   - "Section order: Overview; Goals; Phases; Dependencies; Risks; User Verification; Progress."
 ---

--- a/docs/plans/plan-tag-relationship-refactor.md
+++ b/docs/plans/plan-tag-relationship-refactor.md
@@ -1,12 +1,12 @@
 ---
 id: plan-tag-relationship-refactor
 type: plan
-status: in-progress
+status: proposed
 owners:
   - Will-Conklin
 applies_to:
   - pending-confirmation
-last_updated: 2026-02-10
+last_updated: 2026-02-17
 related:
   - plan-roadmap
   - adr-0001-technology-stack-and-architecture
@@ -15,7 +15,7 @@ supersedes: []
 accepted_by: null
 accepted_at: null
 related_issues:
-  - https://github.com/Will-Conklin/offload/issues/115
+  - https://github.com/Will-Conklin/Offload/issues/219
 structure_notes:
   - "Section order: Overview; Goals; Phases; Dependencies; Risks; User Verification; Progress."
 ---

--- a/docs/plans/plan-testing-polish.md
+++ b/docs/plans/plan-testing-polish.md
@@ -1,12 +1,12 @@
 ---
 id: plan-testing-polish
 type: plan
-status: in-progress
+status: accepted
 owners:
   - Will-Conklin
 applies_to:
   - launch-release
-last_updated: 2026-02-16
+last_updated: 2026-02-18
 related:
   - plan-roadmap
   - plan-ux-accessibility-audit-fixes
@@ -21,8 +21,8 @@ related:
 depends_on:
   - plan-ux-accessibility-audit-fixes
 supersedes: []
-accepted_by: null
-accepted_at: null
+accepted_by: @Will-Conklin
+accepted_at: 2026-01-25
 related_issues:
   - https://github.com/Will-Conklin/offload/issues/116
 structure_notes:
@@ -136,3 +136,4 @@ This phase validates that work and catches any remaining gaps.
 | 2026-01-20 | Plan created from roadmap split. |
 | 2026-02-09 | Plan refined with cross-references to testing artifacts, PRDs, and accessibility audit. |
 | 2026-02-16 | Added non-functional launch gates and mandatory tab-shell accessibility validation tasks from review follow-up. |
+| 2026-02-18 | Returned to `accepted`; implementation has not started yet. |

--- a/docs/plans/plan-trailing-gutter-swipe-delete-affordance.md
+++ b/docs/plans/plan-trailing-gutter-swipe-delete-affordance.md
@@ -7,7 +7,7 @@ owners:
 applies_to:
   - capture
   - organize
-last_updated: 2026-02-16
+last_updated: 2026-02-17
 related:
   - plan-fix-swipe-to-delete
   - plan-resolve-gesture-conflict
@@ -16,7 +16,8 @@ depends_on:
 supersedes: []
 accepted_by: null
 accepted_at: null
-related_issues: []
+related_issues:
+  - https://github.com/Will-Conklin/Offload/issues/220
 structure_notes:
   - "Section order: Overview; Context; Goals; Phases; Dependencies; Risks; User Verification; Progress."
   - "Implementation phases use TDD slices: red -> green -> refactor."

--- a/docs/plans/plan-ux-accessibility-audit-fixes.md
+++ b/docs/plans/plan-ux-accessibility-audit-fixes.md
@@ -6,17 +6,18 @@ owners:
   - Will-Conklin
 applies_to:
   - ios
-last_updated: 2026-02-17
+last_updated: 2026-02-18
 related:
   - plan-advanced-accessibility
   - adr-0003-adhd-focused-ux-ui-guardrails
   - plan-testing-polish
 depends_on: []
 supersedes: []
-accepted_by: null
-accepted_at: null
+accepted_by: @Will-Conklin
+accepted_at: 2026-02-09
 related_issues:
   - https://github.com/Will-Conklin/offload/issues/134
+  - https://github.com/Will-Conklin/Offload/issues/216
 structure_notes:
   - "Section order: Overview; Goals; Phases; Dependencies; Risks; User Verification; Progress."
 ---

--- a/docs/plans/plan-view-decomposition.md
+++ b/docs/plans/plan-view-decomposition.md
@@ -6,15 +6,16 @@ owners:
   - Will-Conklin
 applies_to:
   - ios
-last_updated: 2026-02-17
+last_updated: 2026-02-18
 related:
   - plan-roadmap
 depends_on: []
 supersedes: []
-accepted_by: null
-accepted_at: null
+accepted_by: @Will-Conklin
+accepted_at: 2026-01-19
 related_issues:
   - https://github.com/Will-Conklin/offload/issues/117
+  - https://github.com/Will-Conklin/Offload/issues/217
 structure_notes:
   - "Section order: Overview; Goals; Phases; Dependencies; Risks; User Verification; Progress."
 ---

--- a/docs/reference/reference-frontmatter-schema.md
+++ b/docs/reference/reference-frontmatter-schema.md
@@ -49,7 +49,7 @@ MAY be included when applicable:
 ```yaml
 depends_on: array[string]     # Full paths to dependency docs
 supersedes: array[string]     # IDs of superseded documents
-accepted_by: string|null      # Approver name when accepted
+accepted_by: string|null      # Approver GitHub handle (@username) when accepted
 accepted_at: date|null        # Acceptance date YYYY-MM-DD
 related_issues: array[string] # GitHub issue numbers or URLs
 ```
@@ -220,6 +220,14 @@ applies_to:
 - **Examples:** `[adr-0000-old-decision]`
 - **Rules:** Mark superseded docs as deprecated/superseded
 
+### `accepted_by`
+
+- **Type:** string | null
+- **Format:** GitHub handle with leading `@`
+- **Examples:** `@Will-Conklin`
+- **Rules:** Use handle format for accepted docs; use `null` only when
+  acceptance has not occurred.
+
 ### `structure_notes`
 
 - **Type:** array[string]
@@ -284,7 +292,7 @@ related:
   - prd-0001-product-requirements
 depends_on: []
 supersedes: []
-accepted_by: Will-Conklin
+accepted_by: @Will-Conklin
 accepted_at: 2025-12-30
 related_issues: []
 structure_notes:
@@ -316,7 +324,7 @@ depends_on:
   - docs/adrs/adr-0001-technology-stack.md
   - docs/adrs/adr-0002-terminology-alignment.md
 supersedes: []
-accepted_by: Will-Conklin
+accepted_by: @Will-Conklin
 accepted_at: 2026-01-03
 related_issues:
   - "#123"


### PR DESCRIPTION
## Summary
- align plan lifecycle guidance so post-merge verification uses `uat` state consistently
- require all `uat` issues to be set to project status `Ready` (not `Backlog`)
- backfill plan acceptance metadata (`accepted_by`/`accepted_at`) and normalize active plan statuses based on implementation evidence
- move `Diagnose Idle Memory Pressure` to `uat` and return `Testing & Polish` + `Release Prep` to `accepted`

## Verification
- just lint
- verified key project lanes: #113, #116, #175, and sampled/open `uat` issues in `Ready`
