### PR TITLE
fix(a11y): resolve high-priority VoiceOver audit findings

### DIFF
--- a/ios/Offload/Features/Capture/CaptureItemCard.swift
+++ b/ios/Offload/Features/Capture/CaptureItemCard.swift
@@ -134,6 +134,7 @@ struct ItemCard: View {
         .accessibilityAction(named: AdvancedAccessibilityActionPolicy.moveDestinationActionName(.list)) {
             onMoveTo(.list)
         }
+        .accessibilityElement(children: .combine)
         .contextMenu {
             Button {
                 onMoveTo(.plan)

--- a/ios/Offload/Features/Capture/CaptureSearchView.swift
+++ b/ios/Offload/Features/Capture/CaptureSearchView.swift
@@ -57,6 +57,7 @@ struct CaptureSearchView: View {
                                     .foregroundStyle(Theme.Colors.textSecondary(colorScheme, style: style))
                             }
                             .buttonStyle(.plain)
+                            .accessibilityLabel("Clear search")
                         }
                     }
                     .padding(Theme.Spacing.md)

--- a/ios/Offload/Features/Organize/CollectionDetailItemRows.swift
+++ b/ios/Offload/Features/Organize/CollectionDetailItemRows.swift
@@ -81,6 +81,9 @@ struct HierarchicalItemRow: View {
                 )
                 .buttonStyle(.plain)
                 .disabled(!hasChildren)
+                .accessibilityLabel(hasChildren ? (isExpanded ? "Collapse" : "Expand") : "")
+                .accessibilityValue(hasChildren ? (isExpanded ? "Expanded" : "Collapsed") : "")
+                .accessibilityHidden(!hasChildren)
                 .padding(.trailing, Theme.Spacing.xs)
             }
 
@@ -328,7 +331,6 @@ struct ItemRow: View {
     @Environment(\.collectionRepository) private var collectionRepository
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    @State private var showingMenu = false
     @State private var linkedCollectionName: String?
     @State private var swipeOffset: CGFloat = 0
     @State private var dragStartOffset: CGFloat = 0
@@ -370,25 +372,6 @@ struct ItemRow: View {
             }
             .overlay(alignment: .bottomTrailing) {
                 StarButton(isStarred: item.isStarred, action: toggleStar)
-            }
-            .overlay(alignment: .topTrailing) {
-                Button {
-                    showingMenu = true
-                } label: {
-                    IconTile(
-                        iconName: Icons.more,
-                        iconSize: 16,
-                        tileSize: AdvancedAccessibilityLayoutPolicy.controlSize(for: dynamicTypeSize),
-                        style: .secondaryOutlined(Theme.Colors.textSecondary(colorScheme, style: style))
-                    )
-                }
-                .buttonStyle(.plain)
-                .padding(Theme.Spacing.md)
-                .accessibilityLabel("Item actions")
-                .accessibilityHint("Show options for this item.")
-                .confirmationDialog("Item Actions", isPresented: $showingMenu) {
-                    // Context menu actions (delete removed - use swipe instead)
-                }
             }
             .offset(x: swipeOffset)
             .simultaneousGesture(

--- a/ios/Offload/Features/Organize/OrganizeView.swift
+++ b/ios/Offload/Features/Organize/OrganizeView.swift
@@ -294,6 +294,9 @@ struct OrganizeView: View {
                 .clipShape(Capsule())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(scope.title)
+        .accessibilityValue(selectedScope == scope ? "Selected" : "Not selected")
+        .accessibilityAddTraits(selectedScope == scope ? .isSelected : [])
     }
 
     // MARK: - Create Sheet


### PR DESCRIPTION
## Summary

- Add `.accessibilityElement(children: .combine)` to `ItemCard` so VoiceOver reads capture cards as a single unit instead of fragmented child elements
- Add `accessibilityLabel`/`accessibilityValue` to expand/collapse chevron in `HierarchicalItemRow` so VoiceOver announces expand state
- Add selection state (`.isSelected` trait + `accessibilityValue`) to `OrganizeView` scope picker so VoiceOver announces active Plans/Lists tab
- Add `accessibilityLabel("Clear search")` to clear button in `CaptureSearchView`
- Remove dead "Item actions" button + empty confirmation dialog from `ItemRow` (opened a dialog with zero actions; card already has swipe-to-delete + accessibility actions for all operations)

Addresses the high-priority findings from the Testing & Polish accessibility code audit (backlog item).

## Test plan

- [x] Build succeeds (`xcodebuild build`)
- [x] All unit + UI tests pass (`xcodebuild test`)
- [x] Markdownlint clean
- [ ] On-device VoiceOver validation: verify `ItemCard` reads as single element
- [ ] On-device VoiceOver validation: verify chevron announces "Expand"/"Collapse" + state
- [ ] On-device VoiceOver validation: verify scope picker announces "Selected"/"Not selected"
- [ ] On-device VoiceOver validation: verify clear search button announces "Clear search"
- [ ] Verify no regression on swipe-to-delete after "more" button removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)