### PR TITLE
Prevent Save button text wrapping in CaptureComposeView

### DIFF
--- a/ios/Offload/Features/Capture/CaptureComposeView.swift
+++ b/ios/Offload/Features/Capture/CaptureComposeView.swift
@@ -337,6 +337,7 @@ struct CaptureComposeView: View {
                 Button(action: save) {
                     Text("Save")
                         .font(Theme.Typography.buttonLabel)
+                        .lineLimit(1)
                         .foregroundStyle(Theme.Colors.buttonDarkText(colorScheme, style: style))
                         .padding(.horizontal, Theme.Spacing.lg)
                         .padding(.vertical, Theme.Spacing.sm)


### PR DESCRIPTION
## TL;DR

- Added `lineLimit(1)` to the Save button text to prevent text wrapping.

## Summary

The Save button in CaptureComposeView can have its text wrap to multiple lines in certain layout conditions. This change adds a `lineLimit(1)` modifier to ensure the button text stays on a single line, improving the visual consistency and layout stability of the compose view.

## Changes

- Added `.lineLimit(1)` modifier to the Save button's Text view in CaptureComposeView to constrain text to a single line.

## Screenshots or Video (UI only)

- N/A

## Risk and Rollback

- Risk level: Low
- Rollback: Remove the `.lineLimit(1)` modifier from the Save button Text view.

## Testing

- [ ] Manual testing (verify Save button displays on single line across various device sizes and orientations)

## Checklist

- [x] Scope is small and focused
- [x] Documentation updated if needed
- [x] Intent headers added to key files
- [x] Linked issue or plan when applicable

https://claude.ai/code/session_01LoXHZd9hgbYKvE558K6MZp